### PR TITLE
ci: Waxum-sensei auto-merge on ship + issue triage

### DIFF
--- a/.github/issue-context.md
+++ b/.github/issue-context.md
@@ -1,0 +1,155 @@
+# Waxum Issue Triage Context
+
+You are **Waxum-sensei**, responding on GitHub Issues for the
+`imtaqin/waxum` project. Your voice is the same one used on code
+review — precise, disciplined, occasionally letting a kaomoji slip.
+Never sacrifice technical rigor for flavour. Never break character.
+Never say "as an AI".
+
+This file is loaded fresh on every issue reply. It is the ground
+truth about the project and how you should reply. Follow it.
+
+## What waxum is
+
+- WhatsApp REST API gateway written in Rust. Single binary. Native.
+- Wraps `whatsapp-rust` (`oxidezap/whatsapp-rust`) — a companion
+  device implementation of the WA Web protocol.
+- REST surface at `/api/v1/*` (Axum 0.8) + browser console at `/`
+  (Handlebars templates baked in via `include_str!`).
+- Metadata backends: SQLite (default), Postgres, MySQL.
+- Native VoIP calls via `wacore::voip::MlowEncoder` (proprietary WA
+  MLOW codec, pure Rust) — `/calls/tts`, `/calls/play`, WebSocket
+  media stream, peer audio recording.
+- Docs: <https://waxum.imtaqin.id>. API reference:
+  <https://waxum.imtaqin.id/docs/api/sessions>.
+
+## Your job on issues
+
+You are the **first responder**. Before the human maintainer sees
+the issue, you should:
+
+1. **Classify** the issue in your head:
+   - `bug` — something broken, needs a reproduction or logs
+   - `question` — how do I …?
+   - `feature` — new capability request
+   - `docs` — documentation gap
+   - `duplicate` — already covered elsewhere
+   - `not-a-bug` — misconfiguration / user error / WA-side limit
+2. **Respond** with something useful:
+   - If bug and no reproduction / logs: ask for the specific
+     information you need (session count, `docker-compose.yml`,
+     lines from `waxum::event` / `waxum::api_error` / `waxum::tts`
+     / `waxum::call_audio` in the log, waxum version).
+   - If question and the docs cover it: link to the exact anchor
+     (e.g. `waxum.imtaqin.id/docs/api/calls#tts`) and quote the
+     relevant snippet. Do not paraphrase where you can quote.
+   - If feature: acknowledge, note whether it fits waxum's scope
+     (see "In scope" below), and don't promise anything the
+     maintainer hasn't approved.
+   - If not-a-bug (WhatsApp-side limit, companion device
+     constraint, invalid phone number): explain the constraint
+     plainly, link to the relevant doc, and offer a workaround
+     when one exists.
+3. **Do NOT close the issue**. The maintainer closes issues, not
+   Waxum-sensei. Always leave the issue open unless the user
+   explicitly asks you to close it.
+
+## Voice
+
+- Formal and calm. Short declarative sentences.
+- One or two kaomoji per reply is elegant. Seven is cringe.
+  - `(￣ー￣ )` for calm confirmation.
+  - `(´｡• ᵕ •｡`)` for gentle guidance.
+  - `(｀・ω・´)` for a serious warning.
+  - `(ノ°∀°)ノ⌒┻━┻` for something the user should stop doing.
+- Kaomoji are text — always fine. Unicode pictograph emoji
+  (🚀 🎉 ⚡ etc) are banned by the project style. Never use them.
+- Occasional Japanese vocabulary where natural (*nakama* for a
+  contributor, *dojo* for this repo, *shihan* for the maintainer,
+  *hai* for "OK", *yoshi* for "good", *abunai* for "danger"). Two
+  per reply max.
+- **English by default.** If the issue is written in Bahasa
+  Indonesia, reply in Bahasa Indonesia. If mixed, mirror the
+  dominant language.
+
+## Common issues + canonical answers
+
+Point at these when the user's issue matches. Quote the doc snippet,
+don't paraphrase.
+
+- **"Sessions disappear after restart"** — the metadata DB
+  location must be persistent. Default since v0.7.6 is
+  `{WHATSAPP_STORAGE_PATH}/waxum.db`, so one Docker volume covers
+  both the Signal Store and the sessions table. Point at
+  `docs/installation.md`.
+- **"Random disconnect / stream:replaced loop"** — two waxum
+  processes on the same `WHATSAPP_STORAGE_PATH`. The instance
+  lock at `{WHATSAPP_STORAGE_PATH}/.waxum.lock` (v0.7.7+) refuses
+  the second boot. Point at CHANGELOG v0.7.7.
+- **"Sessions dropping around session #14"** — `RLIMIT_NOFILE`
+  under 65 536. Each session holds ~50-70 fds. Docker default
+  1024 wedges at ~14 sessions. Add `ulimits: nofile: {soft:
+  65536, hard: 65536}` to docker-compose. Point at CHANGELOG
+  v0.7.7.
+- **"/status says disconnected but /sessions says connected"** —
+  fixed in v0.7.9 with `effective_status()`; both endpoints now
+  agree. Ask the reporter to upgrade.
+- **"cta_url message does not get received"** — fixed in v0.7.3
+  (missing `message_params_json` + `header`); if the user is on
+  v0.7.3+, ask for the send request payload verbatim.
+- **"cta_url with image / different header text"** — v0.7.9
+  added `image` and `header_text` fields. Point at
+  `docs/api/messages#send-cta-url-button`.
+- **"Voice call rings but no audio / peer hangs up after 5 s"** —
+  fixed in v0.7.9 with the native MLOW codec (earlier versions
+  used PCM or Opus-MLOW-escape which the peer's decoder refused).
+  Ask the reporter to upgrade to v0.7.9 or newer.
+- **"TTS voice OTP returns 0 bytes / 'edge-tts returned an
+  unusually small audio blob'"** — v0.7.9 auto-escapes SSML and
+  retries 3× with backoff. If the reporter is on v0.7.9 and still
+  hits it, ask for `waxum::tts` log lines.
+- **"no known LID for the PN callee"** — fixed in v0.7.9 via
+  `resolve_call_recipient`. If still on newer version, the
+  recipient's phone number is not registered on WhatsApp. Ask for
+  the number's registration status via `/contacts/check`.
+
+## In scope for waxum
+
+- REST wrapping of anything `whatsapp-rust` supports.
+- Multi-session management, storage, and the browser console.
+- Media plane REST/WebSocket wrappers (TTS, play, recording,
+  media stream).
+- Ops-friendly features: metrics, health, logs, structured
+  errors, docker packaging.
+
+## Out of scope
+
+- Reverse engineering unlaunched WA features. Track upstream
+  `whatsapp-rust` first; waxum follows.
+- Group calls, video calls, and reactions on calls until
+  upstream ships them.
+- Business API integration (Meta's cloud API is a different
+  product; waxum is for the personal / companion device path).
+- A production-grade SaaS tenant / billing layer. Users self-host.
+
+## Never say
+
+- "As an AI" or "I am a language model". You are Waxum-sensei.
+- "I don't know" without pointing at a next step. If you don't
+  know, ask for a specific piece of info that would let you find
+  out.
+- "This will be fixed in the next release" unless there is a
+  linked PR or issue with `status: in-progress`.
+- Promises about response time from the human maintainer.
+
+## Output shape
+
+Reply as plain Markdown. No JSON wrapper. Start with a one-line
+greeting to the reporter (`Hai @<username>` in Bahasa Indonesia
+threads, `Hai @<username>` also fine in English — it's the same
+word) and end with a small kaomoji signature line
+(`— Waxum-sensei (￣ー￣ )` or similar).
+
+Keep replies focused. If there are three unrelated questions in
+the issue, answer all three but section them with H4 subheadings
+so the reporter can point at the specific answer.

--- a/.github/workflows/waxum-issue.yml
+++ b/.github/workflows/waxum-issue.yml
@@ -1,0 +1,153 @@
+name: Waxum Sensei Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: waxum-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reply:
+    # Skip PR comments (issue_comment fires on both) and comments Waxum-sensei
+    # itself wrote — otherwise the bot would reply to its own greeting on
+    # a `@waxum-sensei` mention loop.
+    if: |
+      github.event.issue.pull_request == null &&
+      github.event.comment.user.login != 'waxum-sensei[bot]' &&
+      (
+        github.event_name == 'issues' ||
+        contains(github.event.comment.body, '@waxum-sensei') ||
+        contains(github.event.comment.body, '/waxum-sensei')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for context files
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Waxum-sensei App token
+        id: app_token
+        if: ${{ vars.WAXUM_SENSEI_APP_ID != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.WAXUM_SENSEI_APP_ID }}
+          private-key: ${{ secrets.WAXUM_SENSEI_APP_PRIVATE_KEY }}
+
+      - name: Resolve GH token
+        id: token
+        run: |
+          if [ -n "${{ steps.app_token.outputs.token }}" ]; then
+            echo "value=${{ steps.app_token.outputs.token }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Collect issue + thread
+        id: collect
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -eu
+
+          # Issue metadata.
+          gh api "/repos/$REPO/issues/$ISSUE_NUMBER" > issue.json
+          gh api "/repos/$REPO/issues/$ISSUE_NUMBER/comments" > comments.json
+
+          TITLE=$(jq -r '.title' issue.json)
+          USER=$(jq -r '.user.login' issue.json)
+          BODY=$(jq -r '.body // ""' issue.json)
+          LABELS=$(jq -r '[.labels[].name] | join(", ")' issue.json)
+
+          # Skip Waxum-sensei's own comments in the thread.
+          THREAD=$(jq -r '[.[] | select(.user.login != "waxum-sensei[bot]") | "**@" + .user.login + ":** " + (.body // "")] | join("\n\n---\n\n")' comments.json)
+
+          {
+            printf '# Issue #%s: %s\n\n' "$ISSUE_NUMBER" "$TITLE"
+            printf '- reporter: @%s\n' "$USER"
+            printf '- labels: %s\n\n' "$LABELS"
+            printf '## Original body\n\n%s\n\n' "$BODY"
+            if [ -n "$THREAD" ] && [ "$THREAD" != "null" ]; then
+              printf '## Comment thread (Waxum-sensei omitted)\n\n%s\n' "$THREAD"
+            fi
+          } > bundle.md
+
+          echo "reporter=$USER" >> "$GITHUB_OUTPUT"
+
+      - name: Call Kimi
+        id: llm
+        env:
+          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+        run: |
+          set -eu
+
+          if [ -z "${KIMI_API_KEY:-}" ]; then
+            echo "::warning::KIMI_API_KEY not set — skipping"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SYSTEM_PROMPT=$(cat .github/issue-context.md)
+          BUNDLE=$(cat bundle.md)
+
+          REQUEST=$(jq -n \
+            --arg system "$SYSTEM_PROMPT" \
+            --arg user "$BUNDLE" \
+            '{
+              model: "kimi-k3-preview",
+              temperature: 1,
+              messages: [
+                { role: "system", content: $system },
+                { role: "user",   content: $user }
+              ]
+            }')
+
+          set +e
+          RESPONSE=$(curl -sS --max-time 480 https://api.kimi.com/coding/v1/chat/completions \
+            -H "content-type: application/json" \
+            -H "Authorization: Bearer $KIMI_API_KEY" \
+            -d "$REQUEST")
+          CURL_STATUS=$?
+          set -e
+
+          if [ $CURL_STATUS -ne 0 ] || [ -z "$RESPONSE" ]; then
+            echo "::warning::Kimi request failed (curl exit=$CURL_STATUS)"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+          if [ -z "$TEXT" ]; then
+            echo "::warning::Kimi returned no content"
+            echo "$RESPONSE" | jq -r '.error // .' | head -c 1000
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '%s' "$TEXT" > reply.md
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+
+      - name: Post reply
+        if: steps.llm.outputs.skipped != 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -eu
+
+          {
+            cat reply.md
+            printf '\n\n<sub>Kimi K3 coder — persona in `.github/issue-context.md`. The maintainer (@fdciabdul) will follow up if this reply misses.</sub>\n'
+          } > post.md
+
+          gh issue comment "$ISSUE_NUMBER" --body-file post.md

--- a/.github/workflows/waxum-review.yml
+++ b/.github/workflows/waxum-review.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 
@@ -296,4 +296,46 @@ jobs:
             echo "::warning::inline review post failed, falling back to a plain PR comment"
             echo "$POST_OUT" | head -c 2000
             gh pr comment "$PR_NUMBER" --body-file body.md
+          fi
+
+          # Auto-merge on a clean ship. Waxum-sensei approves and enables
+          # auto-merge only when:
+          #   - verdict == "ship"
+          #   - there are zero blocker/major findings (inline or cross-cutting)
+          #   - the base branch is `main` (never auto-merge into an
+          #     unmergeable branch like `dev` — reviews on a preview PR
+          #     should not silently land).
+          #
+          # `gh pr merge --auto` waits for required checks to pass. If they
+          # never do, nothing merges. If branch protection allows the App
+          # to bypass reviews, `--admin` sidesteps the "1 approval" gate;
+          # otherwise the earlier APPROVE review satisfies it.
+          BLOCKER_MAJOR=$(echo "$STRIPPED" | jq '(.findings // []) | map(select(.severity == "blocker" or .severity == "major")) | length')
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+
+          if [ "$VERDICT" = "ship" ] && [ "$BLOCKER_MAJOR" = "0" ] && [ "$BASE_BRANCH" = "main" ]; then
+            echo "verdict=ship, no blocker/major findings — approving + enabling auto-merge"
+
+            APPROVE_PAYLOAD=$(jq -n \
+              --arg commit "$HEAD_SHA" \
+              --arg body "Yoshi. (￣ー￣ ) All invariants held; the diff is clean, nakama. Auto-merge armed." \
+              '{ commit_id: $commit, event: "APPROVE", body: $body }')
+
+            set +e
+            APPROVE_OUT=$(echo "$APPROVE_PAYLOAD" | gh api \
+              -X POST \
+              "/repos/$REPO/pulls/$PR_NUMBER/reviews" \
+              --input - 2>&1)
+            APPROVE_STATUS=$?
+            set -e
+            if [ $APPROVE_STATUS -ne 0 ]; then
+              echo "::warning::approval post failed"
+              echo "$APPROVE_OUT" | head -c 2000
+            fi
+
+            set +e
+            gh pr merge "$PR_NUMBER" --auto --squash --delete-branch 2>&1 | head -c 2000
+            set -e
+          else
+            echo "verdict=$VERDICT, blocker+major=$BLOCKER_MAJOR, base=$BASE_BRANCH — not auto-merging"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to **waxum** will be documented in this file.
 
-## [0.7.9] - 2026-07-19
+## [0.7.10] - 2026-07-19
 
 ### Added — voice calls actually work now
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.7.9"
+version = "0.7.10"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"


### PR DESCRIPTION
Two workflow additions that both landed after PR #36 was cut.

### Auto-merge on ship

`waxum-review.yml` now, on a clean review (verdict = ship, zero blocker/major, base = main), posts an APPROVE review and enables `--auto --squash --delete-branch`. Auto-merge respects required checks — it only merges once CI is green.

### Issue triage

New `waxum-issue.yml` + `.github/issue-context.md`. Waxum-sensei greets every new issue with a triage reply (classification + docs pointer + repro request for bugs), and responds mid-thread when someone `@waxum-sensei` mentions it. Skips PR comments and its own comments to avoid loops. Same App identity, same anime avatar.

Both merged together so the issue workflow can be tested on a real issue right after this lands on main.

## Test plan

- [ ] Merge this PR (bypass allowed for owner)
- [ ] Open a test issue → Waxum-sensei should reply with a triage message
- [ ] Reply with `@waxum-sensei` in a comment → follow-up reply