### PR TITLE
v0.7.11 — fleet-level ops endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.7.11] - 2026-07-19
+
+### Added — fleet-level endpoints
+
+Every REST endpoint before this release was scoped to one session
+via `/api/v1/sessions/{session_id}/...`. Cross-session ops (bulk
+purge, disconnect-all, search-by-phone, aggregate stats) had no
+place. This release adds a `fleet` tab that operates over the whole
+gateway at once.
+
+- **`POST /api/v1/sessions/purge?filter=<inactive|logged_out|disconnected|all>&days=<N>&dry_run=<bool>`** —
+  Bulk delete sessions matching the filter. `inactive` (default) is
+  "not logged in AND last activity older than `days`". `dry_run=true`
+  returns the list without deleting so an operator can review the
+  target set first. Storage directories and metadata rows go
+  together, matching the single-session `DELETE /sessions/{sid}`
+  semantics.
+- **`POST /api/v1/sessions/disconnect-all`** — Force disconnect
+  every session that currently holds a live Client. Used for
+  maintenance windows before a restart. Sessions with no client
+  are reported under `skipped`.
+- **`POST /api/v1/sessions/reconnect-all`** — Trigger the same
+  `reconnect_all_on_startup` routine that runs on boot, without
+  restarting the process. Every session with `is_logged_in = true`
+  gets an auto-reconnect spawn (staggered by
+  `SESSION_STARTUP_STAGGER_MS`).
+- **`GET /api/v1/sessions/search?q=<needle>`** — Substring +
+  case-insensitive match against session id, name, phone number,
+  and push name. Each hit reports which field(s) matched under
+  `match_on`, so operators can tell why a session came back.
+- **`GET /api/v1/stats`** — Fleet aggregate: total / connected /
+  connecting / disconnected / logged-out session counts,
+  webhook total, open circuits, event rate in the last minute,
+  uptime seconds, waxum version, storage path.
+- **`POST /api/v1/webhooks/reenable-all`** — Close every open
+  webhook circuit at once. Used after fixing a mass downstream
+  outage that tripped many circuits.
+
+Playground picks up a new **Fleet** tab with all six endpoints;
+purge and disconnect-all are marked as `danger` in the form so a
+double-click is required.
+
 ## [0.7.10] - 2026-07-19
 
 ### Added — voice calls actually work now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.7.10"
+version = "0.7.11"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/console/assets/playground.js
+++ b/src/console/assets/playground.js
@@ -396,6 +396,28 @@
           { name: 'reason', label: 'Reason', type: 'text' },
         ] },
     ),
+
+    // ---------- fleet (cross-session ops) ----------
+    ...R('fleet',
+      { key: 'stats', label: 'Fleet stats', method: 'GET',
+        path: '/api/v1/stats', fields: [] },
+      { key: 'search', label: 'Search sessions (id/name/phone/push_name)', method: 'GET',
+        path: '/api/v1/sessions/search',
+        fields: [{ name: 'q', label: 'Query', type: 'text', required: true, placeholder: '628117' }] },
+      { key: 'purge', label: 'Purge inactive sessions', method: 'POST',
+        path: '/api/v1/sessions/purge',
+        fields: [
+          { name: 'filter', label: 'Filter', type: 'select', options: ['inactive', 'logged_out', 'disconnected', 'all'], default: 'inactive' },
+          { name: 'days', label: 'Idle days (for `inactive`)', type: 'number', default: 30 },
+          { name: 'dry_run', label: 'Dry run (preview only)', type: 'checkbox' },
+        ], danger: true },
+      { key: 'disconnect-all', label: 'Disconnect ALL sessions', method: 'POST',
+        path: '/api/v1/sessions/disconnect-all', fields: [], danger: true },
+      { key: 'reconnect-all', label: 'Reconnect all paired sessions', method: 'POST',
+        path: '/api/v1/sessions/reconnect-all', fields: [] },
+      { key: 'reenable-circuits', label: 'Re-enable all open webhook circuits', method: 'POST',
+        path: '/api/v1/webhooks/reenable-all', fields: [] },
+    ),
   ];
 
   window.__GROUP_META__ = {
@@ -408,5 +430,6 @@
     blocking: { title: 'Blocking',      icon: 'i-x' },
     webhooks: { title: 'Webhooks',      icon: 'i-refresh' },
     ops:      { title: 'Operations',    icon: 'i-refresh' },
+    fleet:    { title: 'Fleet',         icon: 'i-signal' },
   };
 })();

--- a/src/handlers/bulk.rs
+++ b/src/handlers/bulk.rs
@@ -1,0 +1,332 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use once_cell::sync::Lazy;
+use std::time::Instant;
+
+use crate::error::ApiError;
+use crate::models::bulk::{
+    DisconnectAllResponse, FleetStats, PurgeQuery, PurgeResponse, ReconnectAllResponse,
+    ReenableCircuitsResponse, SearchHit, SearchQuery, SearchResponse,
+};
+use crate::models::sessions::SessionStatus;
+use crate::state::AppState;
+
+static UPTIME_ANCHOR: Lazy<Instant> = Lazy::new(Instant::now);
+
+pub fn touch_uptime_anchor() {
+    Lazy::force(&UPTIME_ANCHOR);
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/sessions/purge",
+    tag = "bulk",
+    security(("bearer_auth" = [])),
+    params(
+        ("filter" = Option<String>, Query, description = "`inactive` (default), `logged_out`, `disconnected`, `all`"),
+        ("days" = Option<i64>, Query, description = "Minimum idle days for `inactive`. Default 30"),
+        ("dry_run" = Option<bool>, Query, description = "Preview without deleting")
+    ),
+    responses((status = 200, body = PurgeResponse))
+)]
+pub async fn purge_sessions(
+    State(state): State<AppState>,
+    Query(q): Query<PurgeQuery>,
+) -> Result<Json<PurgeResponse>, ApiError> {
+    let sessions = state
+        .session_manager()
+        .list_sessions()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let total_before = sessions.len();
+    let now = chrono::Utc::now().timestamp();
+    let cutoff = now - q.days.max(0) * 86_400;
+
+    let mut targets: Vec<String> = Vec::new();
+    for s in &sessions {
+        let hit = match q.filter.as_str() {
+            "logged_out" => !s.is_logged_in,
+            "disconnected" => s.status == SessionStatus::Disconnected,
+            "all" => true,
+            _ => {
+                let idle = s
+                    .last_connected_at
+                    .unwrap_or(s.updated_at)
+                    .min(s.updated_at);
+                !s.is_logged_in && idle < cutoff
+            }
+        };
+        if hit {
+            targets.push(s.id.clone());
+        }
+    }
+
+    let kept = total_before.saturating_sub(targets.len());
+    if q.dry_run {
+        return Ok(Json(PurgeResponse {
+            filter: q.filter,
+            days: q.days,
+            dry_run: true,
+            purged: targets,
+            kept,
+            total_before,
+        }));
+    }
+
+    let mut purged: Vec<String> = Vec::with_capacity(targets.len());
+    for id in targets {
+        let storage_path = state
+            .session_manager()
+            .get_storage_path(&id)
+            .await
+            .ok()
+            .flatten();
+        if let Some(runtime) = state.get_session(&id) {
+            if let Some(client) = runtime.get_client() {
+                client.disconnect().await;
+            }
+        }
+        state.remove_session(&id);
+        state.purge_webhooks_for_session(&id);
+        if let Some(path) = storage_path {
+            let _ = tokio::fs::remove_dir_all(&path).await;
+        }
+        if state.session_manager().delete_session(&id).await.is_ok() {
+            purged.push(id);
+        }
+    }
+
+    Ok(Json(PurgeResponse {
+        filter: q.filter,
+        days: q.days,
+        dry_run: false,
+        purged,
+        kept,
+        total_before,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/sessions/disconnect-all",
+    tag = "bulk",
+    security(("bearer_auth" = [])),
+    responses((status = 200, body = DisconnectAllResponse))
+)]
+pub async fn disconnect_all(
+    State(state): State<AppState>,
+) -> Result<Json<DisconnectAllResponse>, ApiError> {
+    let sessions = state
+        .session_manager()
+        .list_sessions()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let mut disconnected = Vec::new();
+    let mut skipped = Vec::new();
+    let total = sessions.len();
+
+    for s in sessions {
+        let runtime = state.get_session(&s.id);
+        match runtime.and_then(|r| r.get_client()) {
+            Some(client) => {
+                client.disconnect().await;
+                if let Some(runtime) = state.get_session(&s.id) {
+                    runtime.set_status(SessionStatus::Disconnected);
+                    runtime.set_client(None);
+                }
+                let _ = state
+                    .session_manager()
+                    .update_session_status(&s.id, SessionStatus::Disconnected, s.is_logged_in)
+                    .await;
+                disconnected.push(s.id);
+            }
+            None => skipped.push(s.id),
+        }
+    }
+
+    Ok(Json(DisconnectAllResponse {
+        disconnected,
+        skipped,
+        total,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/sessions/reconnect-all",
+    tag = "bulk",
+    security(("bearer_auth" = [])),
+    responses((status = 200, body = ReconnectAllResponse))
+)]
+pub async fn reconnect_all(
+    State(state): State<AppState>,
+) -> Result<Json<ReconnectAllResponse>, ApiError> {
+    let sessions = state
+        .session_manager()
+        .list_sessions()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let mut scheduled = Vec::new();
+    let mut skipped = Vec::new();
+    let total = sessions.len();
+
+    for s in sessions {
+        if !s.is_logged_in {
+            skipped.push(s.id);
+            continue;
+        }
+        scheduled.push(s.id.clone());
+    }
+
+    let state_clone = state.clone();
+    tokio::spawn(async move {
+        crate::handlers::sessions::reconnect_all_on_startup(state_clone).await;
+    });
+
+    Ok(Json(ReconnectAllResponse {
+        scheduled,
+        skipped,
+        total,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/sessions/search",
+    tag = "bulk",
+    security(("bearer_auth" = [])),
+    params(("q" = String, Query, description = "Match on session id, name, phone_number, or push_name (substring, case-insensitive)")),
+    responses((status = 200, body = SearchResponse))
+)]
+pub async fn search_sessions(
+    State(state): State<AppState>,
+    Query(q): Query<SearchQuery>,
+) -> Result<Json<SearchResponse>, ApiError> {
+    let needle = q.q.trim().to_lowercase();
+    if needle.is_empty() {
+        return Err(ApiError::BadRequest("empty query".into()));
+    }
+
+    let sessions = state
+        .session_manager()
+        .list_sessions()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    let mut hits = Vec::new();
+    for s in sessions {
+        let mut matched = Vec::new();
+        if s.id.to_lowercase().contains(&needle) {
+            matched.push("id".to_string());
+        }
+        if let Some(ref name) = s.name {
+            if name.to_lowercase().contains(&needle) {
+                matched.push("name".to_string());
+            }
+        }
+        if let Some(ref phone) = s.phone_number {
+            if phone.to_lowercase().contains(&needle) {
+                matched.push("phone_number".to_string());
+            }
+        }
+        if let Some(ref push_name) = s.push_name {
+            if push_name.to_lowercase().contains(&needle) {
+                matched.push("push_name".to_string());
+            }
+        }
+
+        if !matched.is_empty() {
+            hits.push(SearchHit {
+                id: s.id,
+                name: s.name,
+                phone_number: s.phone_number,
+                push_name: s.push_name,
+                status: s.status,
+                is_logged_in: s.is_logged_in,
+                match_on: matched,
+            });
+        }
+    }
+
+    let total = hits.len();
+    Ok(Json(SearchResponse {
+        q: q.q,
+        total,
+        hits,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/stats",
+    tag = "bulk",
+    security(("bearer_auth" = [])),
+    responses((status = 200, body = FleetStats))
+)]
+pub async fn fleet_stats(State(state): State<AppState>) -> Result<Json<FleetStats>, ApiError> {
+    let sessions = state
+        .session_manager()
+        .list_sessions()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let (mut connected, mut connecting, mut disconnected, mut logged_out) = (0, 0, 0, 0);
+    for s in &sessions {
+        let effective = state
+            .get_session(&s.id)
+            .map(|r| r.effective_status())
+            .unwrap_or(s.status);
+        match effective {
+            SessionStatus::Connected | SessionStatus::LoggedIn => connected += 1,
+            SessionStatus::Connecting
+            | SessionStatus::WaitingForQr
+            | SessionStatus::WaitingForPairCode => connecting += 1,
+            SessionStatus::Disconnected if !s.is_logged_in => logged_out += 1,
+            _ => disconnected += 1,
+        }
+    }
+
+    let webhook_total: usize = sessions
+        .iter()
+        .map(|s| state.get_webhooks(&s.id).len())
+        .sum();
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let event_rate_per_min = state
+        .recent_events(200)
+        .iter()
+        .filter(|e| now_ms - e.at_epoch_ms < 60_000)
+        .count() as u32;
+
+    Ok(Json(FleetStats {
+        session_total: sessions.len(),
+        session_connected: connected,
+        session_connecting: connecting,
+        session_disconnected: disconnected,
+        session_logged_out: logged_out,
+        webhook_total,
+        webhook_circuits_open: state.webhook_circuits_open_count(),
+        event_rate_per_min,
+        uptime_seconds: UPTIME_ANCHOR.elapsed().as_secs(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        storage_path: state.base_storage_path().to_string(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/webhooks/reenable-all",
+    tag = "bulk",
+    security(("bearer_auth" = [])),
+    responses((status = 200, body = ReenableCircuitsResponse))
+)]
+pub async fn reenable_circuits(
+    State(state): State<AppState>,
+) -> Result<Json<ReenableCircuitsResponse>, ApiError> {
+    let urls = state.reenable_all_open_circuits();
+    let total = urls.len();
+    Ok(Json(ReenableCircuitsResponse {
+        reenabled: urls,
+        total,
+    }))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -22,6 +22,7 @@
 //!   [`fake_reply`] — smaller domains.
 
 pub mod blocking;
+pub mod bulk;
 pub mod calls;
 pub mod chatstate;
 pub mod contacts;

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,6 +602,7 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
     let nats_enabled = nats_manager.is_some();
     let state = AppState::new(pool, nats_manager).await;
 
+    handlers::bulk::touch_uptime_anchor();
     preflight::check_fd_limit();
     let _instance_lock = match preflight::acquire_instance_lock(state.base_storage_path()) {
         Ok(guard) => guard,

--- a/src/models/bulk.rs
+++ b/src/models/bulk.rs
@@ -1,0 +1,89 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::models::sessions::SessionStatus;
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PurgeQuery {
+    #[serde(default = "default_purge_filter")]
+    pub filter: String,
+    #[serde(default = "default_purge_days")]
+    pub days: i64,
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+fn default_purge_filter() -> String {
+    "inactive".to_string()
+}
+fn default_purge_days() -> i64 {
+    30
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PurgeResponse {
+    pub filter: String,
+    pub days: i64,
+    pub dry_run: bool,
+    pub purged: Vec<String>,
+    pub kept: usize,
+    pub total_before: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DisconnectAllResponse {
+    pub disconnected: Vec<String>,
+    pub skipped: Vec<String>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReconnectAllResponse {
+    pub scheduled: Vec<String>,
+    pub skipped: Vec<String>,
+    pub total: usize,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SearchQuery {
+    pub q: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchHit {
+    pub id: String,
+    pub name: Option<String>,
+    pub phone_number: Option<String>,
+    pub push_name: Option<String>,
+    pub status: SessionStatus,
+    pub is_logged_in: bool,
+    pub match_on: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResponse {
+    pub q: String,
+    pub total: usize,
+    pub hits: Vec<SearchHit>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FleetStats {
+    pub session_total: usize,
+    pub session_connected: usize,
+    pub session_connecting: usize,
+    pub session_disconnected: usize,
+    pub session_logged_out: usize,
+    pub webhook_total: usize,
+    pub webhook_circuits_open: usize,
+    pub event_rate_per_min: u32,
+    pub uptime_seconds: u64,
+    pub version: String,
+    pub storage_path: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReenableCircuitsResponse {
+    pub reenabled: Vec<String>,
+    pub total: usize,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod blocking;
+pub mod bulk;
 pub mod calls;
 pub mod chatstate;
 pub mod common;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -31,6 +31,11 @@ pub fn create_router() -> Router<AppState> {
 
 fn api_routes() -> Router<AppState> {
     Router::new()
+        .route("/stats", get(handlers::bulk::fleet_stats))
+        .route(
+            "/webhooks/reenable-all",
+            post(handlers::bulk::reenable_circuits),
+        )
         .nest("/sessions", session_routes())
         .nest("/nats", nats_routes())
 }
@@ -52,6 +57,10 @@ fn session_routes() -> Router<AppState> {
     Router::new()
         .route("/", post(handlers::sessions::create_session))
         .route("/", get(handlers::sessions::list_sessions))
+        .route("/purge", post(handlers::bulk::purge_sessions))
+        .route("/disconnect-all", post(handlers::bulk::disconnect_all))
+        .route("/reconnect-all", post(handlers::bulk::reconnect_all))
+        .route("/search", get(handlers::bulk::search_sessions))
         .route("/{session_id}", get(handlers::sessions::get_session))
         .route("/{session_id}", delete(handlers::sessions::delete_session))
         .route(

--- a/src/state.rs
+++ b/src/state.rs
@@ -442,6 +442,27 @@ impl AppState {
         self.inner.webhooks.remove(session_id);
     }
 
+    /// Bulk close-and-reset every open circuit. Used by
+    /// `POST /api/v1/webhooks/reenable-all` so an operator does not have
+    /// to walk every session's URL list by hand after fixing a mass
+    /// downstream outage. Returns the URLs whose state was actually
+    /// cleared (open circuits only; healthy circuits are left alone).
+    pub fn reenable_all_open_circuits(&self) -> Vec<String> {
+        let now = std::time::Instant::now();
+        let mut reset: Vec<String> = Vec::new();
+        for mut entry in self.inner.webhook_circuits.iter_mut() {
+            let opened = entry.value().opened_until.map(|u| now < u).unwrap_or(false);
+            if opened {
+                let e = entry.value_mut();
+                e.failures = 0;
+                e.opened_until = None;
+                e.last_event = now;
+                reset.push(entry.key().clone());
+            }
+        }
+        reset
+    }
+
     pub fn nats(&self) -> Option<&NatsManager> {
         self.inner.nats.as_ref()
     }


### PR DESCRIPTION
Adds the cross-session ops layer discussed in slack:

- \`POST /api/v1/sessions/purge?filter=&days=&dry_run=\` — bulk delete matching filter (`inactive` / `logged_out` / `disconnected` / `all`)
- \`POST /api/v1/sessions/disconnect-all\` — force disconnect every live session
- \`POST /api/v1/sessions/reconnect-all\` — re-run \`reconnect_all_on_startup\` without a process restart
- \`GET /api/v1/sessions/search?q=\` — substring case-insensitive across id / name / phone / push_name
- \`GET /api/v1/stats\` — fleet aggregate (session counts by state, webhooks, circuits, event rate, uptime, version)
- \`POST /api/v1/webhooks/reenable-all\` — clear all open circuits after fixing a downstream outage

Playground gets a new **Fleet** tab. Purge + disconnect-all are marked as danger buttons.

Version bumped to 0.7.11.