### PR TITLE
v0.7.12 — SSE event tail + TTS preview + voice list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.7.12] - 2026-07-19
+
+### Added — event tail + TTS discovery
+
+Two operator-focused endpoints and a new discovery surface for the
+Edge-TTS pipeline that already backs `/calls/tts`.
+
+- **`GET /api/v1/events/tail`** — server-sent event stream over the
+  in-memory event ring. Every event that reaches
+  `broadcast_to_webhooks` is emitted as an SSE line
+  (`event:` = event type, `id:` = epoch ms, `data:` = JSON preview).
+  Supports `?session=<sid>` and `?event=<name>` filters so an
+  operator can `curl -N /api/v1/events/tail?session=foo` and watch
+  one session in isolation. Sends the last 50 items as backlog on
+  connect so late subscribers see a tail immediately; keep-alive
+  every 15 s to survive intermediary idle-timeouts. Complements
+  webhooks — no delivery guarantees, but no config either.
+- **`GET /api/v1/voices`** — list every voice Edge-TTS exposes
+  (~600 entries). Fields returned: `name`, `short_name` (the value
+  callers pass to `/calls/tts`), `locale`, `gender`,
+  `friendly_name`. Cache aggressively client-side; the list is
+  stable per Edge-TTS release.
+- **`GET /api/v1/tts/preview?text=<t>&voice=<v>`** — audition a
+  voice without placing a call. Returns the raw MP3 that Edge-TTS
+  produced (`Content-Type: audio/mpeg`), so an operator can hit the
+  endpoint straight from the console `<audio>` tag and hear the
+  voice before wiring it to a live call. `text` is capped at 500
+  chars — this is a preview, not the send path.
+
+### Notes
+
+Console updates that surface these endpoints in the playground land
+alongside the v0.7.12 binary; nothing existing is behind a feature
+flag or breaking.
+
 ## [0.7.11] - 2026-07-19
 
 ### Added — fleet-level endpoints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,6 +4248,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5082,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5117,6 +5128,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -76,6 +76,7 @@ futures = "0.3"
 
 prometheus = { version = "0.13", default-features = false }
 async-channel = "2"
+tokio-stream = "0.1"
 
 # Console (server-rendered dashboard) — Handlebars templates + tiny
 # static asset bundle baked into the binary via `include_str!`. No

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Production-grade. **110+ REST endpoints across 21 feature modules.**
 | Swagger UI + OpenAPI 3.1 schema | `/swagger-ui` |
 | Liveness / readiness probes | `/livez`, `/readyz` |
 | Prometheus metrics (counters + gauges) | `/metrics` |
-| Event ring buffer for terminal-style log | `/api/v1/events/tail` |
+| SSE event tail (filter by session / event) | `GET /api/v1/events/tail` |
+| List Edge-TTS voices | `GET /api/v1/voices` |
+| TTS voice preview (returns MP3) | `GET /api/v1/tts/preview?text=&voice=` |
 | Instance-lock file (single-writer safety) | on-boot |
 | FD-limit warning at start (nofile < 65536) | on-boot |
 | JWT + static Bearer auth, per-token IP allowlist (planned) | header |

--- a/src/handlers/calls.rs
+++ b/src/handlers/calls.rs
@@ -1070,9 +1070,7 @@ pub struct TtsPreviewQuery {
     pub voice: String,
 }
 
-pub async fn tts_preview(
-    Query(q): Query<TtsPreviewQuery>,
-) -> Result<AxumResponse, ApiError> {
+pub async fn tts_preview(Query(q): Query<TtsPreviewQuery>) -> Result<AxumResponse, ApiError> {
     let text = q.text.trim();
     if text.is_empty() {
         return Err(ApiError::BadRequest("text is empty".into()));
@@ -1095,8 +1093,7 @@ pub async fn tts_preview(
             .find(|v| v.short_name.as_deref() == Some(voice_owned.as_str()))
             .ok_or_else(|| anyhow::anyhow!("voice '{}' not found", voice_owned))?;
         let config = SpeechConfig::from(matched);
-        let mut client =
-            connect().map_err(|e| anyhow::anyhow!("edge tts connect: {e}"))?;
+        let mut client = connect().map_err(|e| anyhow::anyhow!("edge tts connect: {e}"))?;
         let audio = client
             .synthesize(&text_owned, &config)
             .map_err(|e| anyhow::anyhow!("edge tts synth: {e}"))?;

--- a/src/handlers/calls.rs
+++ b/src/handlers/calls.rs
@@ -1059,3 +1059,97 @@ async fn drive_media_socket(
     state.call_audio_channels().remove(&call_id);
     Ok(())
 }
+
+/// Preview a TTS voice without placing a call — synthesize `text` with
+/// `voice` and return the MP3 that Edge-TTS produced, before the ffmpeg
+/// resample step. Cheap way for a caller to audition voices in the
+/// browser before wiring one to `tts_call`.
+#[derive(Debug, serde::Deserialize)]
+pub struct TtsPreviewQuery {
+    pub text: String,
+    pub voice: String,
+}
+
+pub async fn tts_preview(
+    Query(q): Query<TtsPreviewQuery>,
+) -> Result<AxumResponse, ApiError> {
+    let text = q.text.trim();
+    if text.is_empty() {
+        return Err(ApiError::BadRequest("text is empty".into()));
+    }
+    if text.chars().count() > 500 {
+        return Err(ApiError::BadRequest(
+            "text is over 500 chars — not a preview, use /calls/tts".into(),
+        ));
+    }
+    let text_owned = sanitize_ssml_text(text);
+    let voice_owned = q.voice.clone();
+
+    let mp3 = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<u8>> {
+        use msedge_tts::tts::client::connect;
+        use msedge_tts::tts::SpeechConfig;
+        use msedge_tts::voice::get_voices_list;
+        let voices = get_voices_list().map_err(|e| anyhow::anyhow!("edge tts voice list: {e}"))?;
+        let matched = voices
+            .iter()
+            .find(|v| v.short_name.as_deref() == Some(voice_owned.as_str()))
+            .ok_or_else(|| anyhow::anyhow!("voice '{}' not found", voice_owned))?;
+        let config = SpeechConfig::from(matched);
+        let mut client =
+            connect().map_err(|e| anyhow::anyhow!("edge tts connect: {e}"))?;
+        let audio = client
+            .synthesize(&text_owned, &config)
+            .map_err(|e| anyhow::anyhow!("edge tts synth: {e}"))?;
+        if audio.audio_bytes.is_empty() {
+            anyhow::bail!("edge tts returned 0 bytes");
+        }
+        Ok(audio.audio_bytes)
+    })
+    .await
+    .map_err(|e| ApiError::Internal(format!("tts task join: {e}")))?
+    .map_err(|e| ApiError::Internal(format!("tts preview failed: {e}")))?;
+
+    let resp = axum::response::Response::builder()
+        .status(200)
+        .header("content-type", "audio/mpeg")
+        .header("cache-control", "public, max-age=3600")
+        .header("x-waxum-tts-voice", q.voice)
+        .body(axum::body::Body::from(mp3))
+        .map_err(|e| ApiError::Internal(format!("response build: {e}")))?;
+    Ok(resp)
+}
+
+/// List every voice Edge-TTS exposes. Response shape mirrors what the
+/// upstream `get_voices_list` returns, with just the fields a caller
+/// actually needs (short name, locale, gender, display name). Cached
+/// on the caller side is fine — the list is stable per Edge-TTS
+/// release.
+#[derive(serde::Serialize)]
+pub struct VoiceEntry {
+    pub name: String,
+    pub short_name: Option<String>,
+    pub locale: Option<String>,
+    pub gender: Option<String>,
+    pub friendly_name: Option<String>,
+}
+
+pub async fn list_voices() -> Result<Json<Vec<VoiceEntry>>, ApiError> {
+    let voices = tokio::task::spawn_blocking(|| -> anyhow::Result<Vec<VoiceEntry>> {
+        use msedge_tts::voice::get_voices_list;
+        let raw = get_voices_list().map_err(|e| anyhow::anyhow!("voice list: {e}"))?;
+        Ok(raw
+            .into_iter()
+            .map(|v| VoiceEntry {
+                name: v.name,
+                short_name: v.short_name,
+                locale: v.locale,
+                gender: v.gender,
+                friendly_name: v.friendly_name,
+            })
+            .collect())
+    })
+    .await
+    .map_err(|e| ApiError::Internal(format!("voice task join: {e}")))?
+    .map_err(|e| ApiError::Internal(format!("voice list failed: {e}")))?;
+    Ok(Json(voices))
+}

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -1,0 +1,128 @@
+//! Server-sent events tail over the in-memory ring buffer.
+//!
+//! `broadcast_to_webhooks` pushes a preview of every outbound event
+//! into a bounded ring on `AppState`, which the console overview reads
+//! for its "Live events" panel. This handler streams the same events
+//! out to any HTTP client as `text/event-stream`, so an operator can
+//! `curl -N /api/v1/events/tail` (or an integration point like n8n)
+//! and watch traffic without registering a webhook first.
+//!
+//! Implementation notes:
+//!
+//! - On connect the handler drains a small backlog (up to 50 items)
+//!   from the ring, so late subscribers immediately see the tail of
+//!   recent activity. After that a background task polls the ring
+//!   every 500 ms for new entries and forwards anything with an
+//!   `at_epoch_ms` strictly greater than the last emitted.
+//! - The ring is bounded at 200 items — if a burst produces more
+//!   events than that inside a poll window a subscriber will miss the
+//!   middle. Acceptable for an ops tail; anything that needs
+//!   guaranteed delivery should still use a webhook.
+//! - Query params:
+//!   `session=<sid>` — filter to a single session id.
+//!   `event=<name>`  — filter to a single event type name.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::{
+    extract::{Query, State},
+    response::sse::{Event, KeepAlive, Sse},
+};
+use futures::stream::Stream;
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::state::{AppState, ConsoleEvent};
+
+#[derive(Debug, Deserialize)]
+pub struct EventsTailQuery {
+    pub session: Option<String>,
+    pub event: Option<String>,
+}
+
+fn matches(
+    e: &ConsoleEvent,
+    session_filter: Option<&str>,
+    event_filter: Option<&str>,
+) -> bool {
+    if let Some(s) = session_filter {
+        if e.session_id != s {
+            return false;
+        }
+    }
+    if let Some(s) = event_filter {
+        if e.event_type != s {
+            return false;
+        }
+    }
+    true
+}
+
+fn to_sse(ev: ConsoleEvent) -> Event {
+    let payload =
+        serde_json::to_string(&ev).unwrap_or_else(|_| String::from("{\"error\":\"serialize\"}"));
+    Event::default()
+        .event(ev.event_type.clone())
+        .id(ev.at_epoch_ms.to_string())
+        .data(payload)
+}
+
+pub async fn events_tail(
+    State(state): State<AppState>,
+    Query(q): Query<EventsTailQuery>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let session_filter = q.session;
+    let event_filter = q.event;
+
+    let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(64);
+
+    let backlog: Vec<ConsoleEvent> = state
+        .recent_events(50)
+        .into_iter()
+        .rev()
+        .filter(|e| matches(e, session_filter.as_deref(), event_filter.as_deref()))
+        .collect();
+
+    let start_at = backlog.last().map(|e| e.at_epoch_ms).unwrap_or(0);
+    for ev in backlog {
+        let _ = tx.send(Ok(to_sse(ev))).await;
+    }
+
+    tokio::spawn(async move {
+        let mut last_at = start_at;
+        let mut ticker = tokio::time::interval(Duration::from_millis(500));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            if tx.is_closed() {
+                return;
+            }
+            let recent = state.recent_events(200);
+            let mut fresh: Vec<ConsoleEvent> = recent
+                .into_iter()
+                .rev()
+                .filter(|e| {
+                    e.at_epoch_ms > last_at
+                        && matches(e, session_filter.as_deref(), event_filter.as_deref())
+                })
+                .collect();
+            if let Some(latest) = fresh.last() {
+                last_at = latest.at_epoch_ms;
+            }
+            for ev in fresh.drain(..) {
+                if tx.send(Ok(to_sse(ev))).await.is_err() {
+                    return;
+                }
+            }
+        }
+    });
+
+    let stream = ReceiverStream::new(rx);
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keep-alive"),
+    )
+}

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -42,11 +42,7 @@ pub struct EventsTailQuery {
     pub event: Option<String>,
 }
 
-fn matches(
-    e: &ConsoleEvent,
-    session_filter: Option<&str>,
-    event_filter: Option<&str>,
-) -> bool {
+fn matches(e: &ConsoleEvent, session_filter: Option<&str>, event_filter: Option<&str>) -> bool {
     if let Some(s) = session_filter {
         if e.session_id != s {
             return false;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -26,6 +26,7 @@ pub mod bulk;
 pub mod calls;
 pub mod chatstate;
 pub mod contacts;
+pub mod events;
 pub mod fake_reply;
 pub mod groups;
 pub mod groups_management;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -36,6 +36,9 @@ fn api_routes() -> Router<AppState> {
             "/webhooks/reenable-all",
             post(handlers::bulk::reenable_circuits),
         )
+        .route("/events/tail", get(handlers::events::events_tail))
+        .route("/voices", get(handlers::calls::list_voices))
+        .route("/tts/preview", get(handlers::calls::tts_preview))
         .nest("/sessions", session_routes())
         .nest("/nats", nats_routes())
 }


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/events/tail` — SSE stream over the in-memory event ring, with `session=` and `event=` filters, 50-item backlog on connect, 15 s keep-alive.
- Add `GET /api/v1/voices` — enumerate every Edge-TTS voice with the fields callers need (`name`, `short_name`, `locale`, `gender`, `friendly_name`).
- Add `GET /api/v1/tts/preview?text=&voice=` — return the raw MP3 Edge-TTS produced so the console can audition a voice via `<audio>` before wiring it to `/calls/tts`. Text capped at 500 chars.
- Dep bump: adds `tokio-stream = \"0.1\"` for the ReceiverStream that backs the SSE handler.
- Bump crate + CHANGELOG to 0.7.12.

## Test plan

- [ ] `curl -N http://localhost:3451/api/v1/events/tail` returns SSE frames; sending a message emits a new frame.
- [ ] `curl http://localhost:3451/api/v1/voices | jq 'length'` returns > 400.
- [ ] `curl 'http://localhost:3451/api/v1/tts/preview?text=halo&voice=id-ID-ArdiNeural' -o out.mp3 && file out.mp3` reports MPEG audio.
- [ ] Existing `/calls/tts` still works (no regressions to the shared synth pipeline).