### PR TITLE
v0.7.13 — session tags with JSON snapshot persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.7.13] - 2026-07-20
+
+### Added — session tags
+
+Operators managing tens or hundreds of sessions have had no way to
+group them for filtering. This release adds a lightweight tag
+system: any short label (`cs`, `blast-campaign-2`, `client:acme`,
+`region:jkt`) can be attached to a session, and the session listing
+gains a `?tag=` filter.
+
+Tags are held in-memory on `AppState` and snapshotted to
+`{WHATSAPP_STORAGE_PATH}/session_tags.json` on every mutation, so a
+restart preserves organisation. A future release will promote them
+to first-class DB rows once the surface stabilises; for now the
+JSON file is authoritative on disk and read once at startup.
+
+- **`GET /api/v1/sessions/{sid}/tags`** — list the tags on a
+  session. Returns `{session_id, tags: [...]}` with tags sorted
+  alphabetically.
+- **`PUT /api/v1/sessions/{sid}/tags`** — replace the full tag
+  set. Body `{"tags": ["cs", "team:jakarta"]}`. Empty strings and
+  whitespace-only entries are dropped; sending an empty array
+  removes the session from the tag map entirely.
+- **`POST /api/v1/sessions/{sid}/tags`** — add one tag. Body
+  `{"tag": "vip"}`. Response reports `changed: true|false` so the
+  caller can distinguish a real add from an already-present tag.
+- **`DELETE /api/v1/sessions/{sid}/tags/{tag}`** — remove one
+  tag. Session drops out of the map once its last tag is gone.
+- **`GET /api/v1/tags`** — enumerate every distinct tag across
+  the fleet with the number of sessions carrying it, sorted by
+  count then name. Powers a "tag cloud" in the console.
+- **`GET /api/v1/sessions?tag=<t>`** — the existing session
+  listing accepts `?tag=<name>` and returns only sessions carrying
+  that tag. Case-sensitive, trimmed on both sides.
+
+Deleting a session (`DELETE /api/v1/sessions/{sid}`) now also
+drops any tags associated with it, so the JSON snapshot does not
+accumulate orphans.
+
 ## [0.7.12] - 2026-07-19
 
 ### Added — event tail + TTS discovery

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Production-grade. **110+ REST endpoints across 21 feature modules.**
 | Swagger UI + OpenAPI 3.1 schema | `/swagger-ui` |
 | Liveness / readiness probes | `/livez`, `/readyz` |
 | Prometheus metrics (counters + gauges) | `/metrics` |
+| Session tags (in-memory + JSON snapshot) | `GET/PUT/POST /api/v1/sessions/{sid}/tags`, `DELETE .../tags/{tag}`, `GET /api/v1/tags`, `GET /api/v1/sessions?tag=` |
 | SSE event tail (filter by session / event) | `GET /api/v1/events/tail` |
 | List Edge-TTS voices | `GET /api/v1/voices` |
 | TTS voice preview (returns MP3) | `GET /api/v1/tts/preview?text=&voice=` |
@@ -139,7 +140,7 @@ Production-grade. **110+ REST endpoints across 21 feature modules.**
 | Blast queue engine (bulk send, dedup, retry, DLQ) | scoped |
 | Scheduled send (`send_at` ISO) | scoped |
 | S3 backend for media & recordings | scoped |
-| Session tags / groups | scoped |
+| ~~Session tags / groups~~ | shipped 0.7.13 |
 | TypeScript SDK (auto-gen from OpenAPI) | scoped |
 | Rust client crate | scoped |
 | n8n community node | scoped |

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -40,4 +40,5 @@ pub mod presence;
 pub mod privacy;
 pub mod sessions;
 pub mod status;
+pub mod tags;
 pub mod webhooks;

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -102,6 +102,11 @@ pub async fn create_session(
     Ok(Json(CreateSessionResponse { session }))
 }
 
+#[derive(serde::Deserialize)]
+pub struct ListSessionsQuery {
+    pub tag: Option<String>,
+}
+
 #[utoipa::path(
     get,
     path = "/api/v1/sessions",
@@ -113,6 +118,7 @@ pub async fn create_session(
 )]
 pub async fn list_sessions(
     State(state): State<AppState>,
+    axum::extract::Query(q): axum::extract::Query<ListSessionsQuery>,
 ) -> Result<Json<SessionListResponse>, ApiError> {
     let sessions = state
         .session_manager()
@@ -120,8 +126,17 @@ pub async fn list_sessions(
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 
+    let tag_filter = q.tag.as_deref().map(|s| s.trim()).filter(|s| !s.is_empty());
+    let allowed: Option<std::collections::HashSet<String>> =
+        tag_filter.map(|t| state.sessions_with_tag(t).into_iter().collect());
+
     let mut updated_sessions = Vec::with_capacity(sessions.len());
     for mut session in sessions {
+        if let Some(ref set) = allowed {
+            if !set.contains(&session.id) {
+                continue;
+            }
+        }
         if let Some(runtime) = state.get_session(&session.id) {
             session.status = runtime.effective_status();
             session.is_logged_in = session.status == SessionStatus::LoggedIn;
@@ -193,6 +208,7 @@ pub async fn delete_session(
 
     state.remove_session(&session_id);
     state.purge_webhooks_for_session(&session_id);
+    state.drop_tags_for(&session_id).await;
 
     if let Some(storage_path) = state
         .session_manager()

--- a/src/handlers/tags.rs
+++ b/src/handlers/tags.rs
@@ -1,0 +1,122 @@
+//! Session tag CRUD.
+//!
+//! Tags are free-form short strings an operator attaches to a session
+//! to organise a fleet — e.g. `cs`, `blast-campaign-2`, `client:acme`,
+//! `region:jkt`. They are held in-memory on [`AppState`] and snapshotted
+//! to `{WHATSAPP_STORAGE_PATH}/session_tags.json` on every mutation, so
+//! restarts do not wipe organisation. Not on the send hot path — the
+//! session listing consults them only when `?tag=` is present, and the
+//! console reads them for its overview grouping.
+//!
+//! Endpoints:
+//! - `GET    /api/v1/sessions/{sid}/tags` — list tags on a session.
+//! - `PUT    /api/v1/sessions/{sid}/tags` — replace the full set.
+//! - `POST   /api/v1/sessions/{sid}/tags` — add a single tag.
+//! - `DELETE /api/v1/sessions/{sid}/tags/{tag}` — remove one tag.
+//! - `GET    /api/v1/tags` — list every distinct tag with counts.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+#[derive(Serialize)]
+pub struct TagListResponse {
+    pub session_id: String,
+    pub tags: Vec<String>,
+}
+
+pub async fn list_session_tags(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<TagListResponse>, ApiError> {
+    let tags = state.list_tags(&session_id);
+    Ok(Json(TagListResponse { session_id, tags }))
+}
+
+#[derive(Deserialize)]
+pub struct ReplaceTagsBody {
+    pub tags: Vec<String>,
+}
+
+pub async fn replace_session_tags(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(body): Json<ReplaceTagsBody>,
+) -> Result<Json<TagListResponse>, ApiError> {
+    state.set_tags(&session_id, body.tags).await;
+    let tags = state.list_tags(&session_id);
+    Ok(Json(TagListResponse { session_id, tags }))
+}
+
+#[derive(Deserialize)]
+pub struct AddTagBody {
+    pub tag: String,
+}
+
+#[derive(Serialize)]
+pub struct TagMutateResponse {
+    pub session_id: String,
+    pub tag: String,
+    pub changed: bool,
+    pub tags: Vec<String>,
+}
+
+pub async fn add_session_tag(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(body): Json<AddTagBody>,
+) -> Result<Json<TagMutateResponse>, ApiError> {
+    if body.tag.trim().is_empty() {
+        return Err(ApiError::BadRequest("tag is empty".into()));
+    }
+    let changed = state.add_tag(&session_id, &body.tag).await;
+    Ok(Json(TagMutateResponse {
+        session_id: session_id.clone(),
+        tag: body.tag,
+        changed,
+        tags: state.list_tags(&session_id),
+    }))
+}
+
+pub async fn remove_session_tag(
+    State(state): State<AppState>,
+    Path((session_id, tag)): Path<(String, String)>,
+) -> Result<Json<TagMutateResponse>, ApiError> {
+    let changed = state.remove_tag(&session_id, &tag).await;
+    Ok(Json(TagMutateResponse {
+        session_id: session_id.clone(),
+        tag,
+        changed,
+        tags: state.list_tags(&session_id),
+    }))
+}
+
+#[derive(Serialize)]
+pub struct TagCount {
+    pub tag: String,
+    pub session_count: usize,
+}
+
+pub async fn list_all_tags(State(state): State<AppState>) -> Result<Json<Vec<TagCount>>, ApiError> {
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for sid in state.all_session_ids_with_tags() {
+        for tag in state.list_tags(&sid) {
+            *counts.entry(tag).or_insert(0) += 1;
+        }
+    }
+    let mut out: Vec<TagCount> = counts
+        .into_iter()
+        .map(|(tag, session_count)| TagCount { tag, session_count })
+        .collect();
+    out.sort_by(|a, b| {
+        b.session_count
+            .cmp(&a.session_count)
+            .then(a.tag.cmp(&b.tag))
+    });
+    Ok(Json(out))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -39,6 +39,7 @@ fn api_routes() -> Router<AppState> {
         .route("/events/tail", get(handlers::events::events_tail))
         .route("/voices", get(handlers::calls::list_voices))
         .route("/tts/preview", get(handlers::calls::tts_preview))
+        .route("/tags", get(handlers::tags::list_all_tags))
         .nest("/sessions", session_routes())
         .nest("/nats", nats_routes())
 }
@@ -419,6 +420,16 @@ fn session_routes() -> Router<AppState> {
         .route(
             "/{session_id}/webhooks/{webhook_id}/enable",
             post(handlers::webhooks::reenable_webhook),
+        )
+        .route(
+            "/{session_id}/tags",
+            get(handlers::tags::list_session_tags)
+                .put(handlers::tags::replace_session_tags)
+                .post(handlers::tags::add_session_tag),
+        )
+        .route(
+            "/{session_id}/tags/{tag}",
+            delete(handlers::tags::remove_session_tag),
         )
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -236,6 +236,12 @@ struct AppStateInner {
 
     pub call_audio_channels: DashMap<String, ActiveCallAudio>,
 
+    /// In-memory tag membership per session. `DashMap<session_id, HashSet<tag>>`.
+    /// Persisted as `{base_storage_path}/session_tags.json` on every mutation
+    /// so restarts do not wipe organisation. Not on the hot path — tags are
+    /// only read on the console + session listing filters.
+    pub session_tags: DashMap<String, std::collections::HashSet<String>>,
+
     /// Bounded ring of the last N events crossing `broadcast_to_webhooks`.
     /// Backs the console overview "Live events" panel and also serves as
     /// the source for the terminal event log line.
@@ -297,7 +303,7 @@ impl AppState {
 
         let session_manager = SessionManager::new(pool);
 
-        Self {
+        let state = Self {
             inner: Arc::new(AppStateInner {
                 session_manager,
                 sessions: DashMap::new(),
@@ -309,7 +315,143 @@ impl AppState {
                 active_calls: DashMap::new(),
                 call_audio_channels: DashMap::new(),
                 event_ring: parking_lot::Mutex::new(std::collections::VecDeque::with_capacity(200)),
+                session_tags: DashMap::new(),
             }),
+        };
+
+        let path = Self::tags_file_path(&state.inner.base_storage_path);
+        if let Ok(bytes) = tokio::fs::read(&path).await {
+            if let Ok(map) =
+                serde_json::from_slice::<std::collections::HashMap<String, Vec<String>>>(&bytes)
+            {
+                for (sid, tags) in map {
+                    state
+                        .inner
+                        .session_tags
+                        .insert(sid, tags.into_iter().collect());
+                }
+                tracing::info!(
+                    target: "waxum::tags",
+                    entries = state.inner.session_tags.len(),
+                    "loaded session tags from {}",
+                    path.display()
+                );
+            }
+        }
+
+        state
+    }
+
+    fn tags_file_path(base: &str) -> std::path::PathBuf {
+        std::path::Path::new(base).join("session_tags.json")
+    }
+
+    async fn persist_tags(&self) {
+        let snapshot: std::collections::HashMap<String, Vec<String>> = self
+            .inner
+            .session_tags
+            .iter()
+            .map(|kv| (kv.key().clone(), kv.value().iter().cloned().collect()))
+            .collect();
+        let path = Self::tags_file_path(&self.inner.base_storage_path);
+        match serde_json::to_vec_pretty(&snapshot) {
+            Ok(bytes) => {
+                if let Err(e) = tokio::fs::write(&path, bytes).await {
+                    tracing::warn!(target: "waxum::tags", "persist tags failed: {e}");
+                }
+            }
+            Err(e) => tracing::warn!(target: "waxum::tags", "serialise tags failed: {e}"),
+        }
+    }
+
+    pub fn list_tags(&self, session_id: &str) -> Vec<String> {
+        self.inner
+            .session_tags
+            .get(session_id)
+            .map(|kv| {
+                let mut v: Vec<String> = kv.value().iter().cloned().collect();
+                v.sort();
+                v
+            })
+            .unwrap_or_default()
+    }
+
+    pub async fn set_tags(&self, session_id: &str, tags: Vec<String>) {
+        let cleaned: std::collections::HashSet<String> = tags
+            .into_iter()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if cleaned.is_empty() {
+            self.inner.session_tags.remove(session_id);
+        } else {
+            self.inner
+                .session_tags
+                .insert(session_id.to_string(), cleaned);
+        }
+        self.persist_tags().await;
+    }
+
+    pub async fn add_tag(&self, session_id: &str, tag: &str) -> bool {
+        let tag = tag.trim().to_string();
+        if tag.is_empty() {
+            return false;
+        }
+        let inserted = self
+            .inner
+            .session_tags
+            .entry(session_id.to_string())
+            .or_default()
+            .insert(tag);
+        if inserted {
+            self.persist_tags().await;
+        }
+        inserted
+    }
+
+    pub async fn remove_tag(&self, session_id: &str, tag: &str) -> bool {
+        let mut changed = false;
+        let mut drop_key = false;
+        if let Some(mut entry) = self.inner.session_tags.get_mut(session_id) {
+            changed = entry.remove(tag);
+            if entry.is_empty() {
+                drop_key = true;
+            }
+        }
+        if drop_key {
+            self.inner.session_tags.remove(session_id);
+        }
+        if changed {
+            self.persist_tags().await;
+        }
+        changed
+    }
+
+    pub fn sessions_with_tag(&self, tag: &str) -> Vec<String> {
+        self.inner
+            .session_tags
+            .iter()
+            .filter_map(|kv| {
+                if kv.value().contains(tag) {
+                    Some(kv.key().clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn all_session_ids_with_tags(&self) -> Vec<String> {
+        self.inner
+            .session_tags
+            .iter()
+            .map(|kv| kv.key().clone())
+            .collect()
+    }
+
+    pub async fn drop_tags_for(&self, session_id: &str) {
+        if self.inner.session_tags.remove(session_id).is_some() {
+            self.persist_tags().await;
         }
     }
 


### PR DESCRIPTION
## Summary

- 5 new endpoints for tagging sessions (`GET/PUT/POST/DELETE /api/v1/sessions/{sid}/tags`, `GET /api/v1/tags`).
- Session listing gains `?tag=<name>` filter.
- Tags held in-memory on AppState, snapshotted to `{WHATSAPP_STORAGE_PATH}/session_tags.json` on every mutation.
- Session delete cascades to tag removal so the JSON file does not accumulate orphans.
- Bump crate + CHANGELOG to 0.7.13.

## Test plan

- [ ] `curl -X PUT localhost:3451/api/v1/sessions/foo/tags -d '{"tags":["cs","vip"]}'` returns `{tags:[cs,vip]}`.
- [ ] Restart process, `curl localhost:3451/api/v1/sessions/foo/tags` still returns `[cs,vip]`.
- [ ] `curl 'localhost:3451/api/v1/sessions?tag=cs'` filters correctly.
- [ ] `curl -X DELETE localhost:3451/api/v1/sessions/foo` removes session id from JSON snapshot.