### PR TITLE
v0.9.1 — fix broken v0.9.0 release (drop bundled whisper.cpp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to **waxum** will be documented in this file.
 
-## [0.9.0] - 2026-07-24
+## [0.9.1] - 2026-07-24
 
-### Added — video calling + local transcription
+`v0.9.0`'s tag exists but was never actually released — its build
+pulled in `whisper-rs`, which compiles whisper.cpp (C++) into the
+binary and broke the Windows cross-compile job in CI. Superseded by
+this version before any binaries or Docker images went out.
+
+### Added — video calling + call transcription
 
 - **Video calls** — `calls/media/ws?kind=av` places a call with both
   audio and video, relaying raw H.264 Annex-B access units to/from the
@@ -13,12 +18,12 @@ All notable changes to **waxum** will be documented in this file.
   its own H.264 encoder/decoder (e.g. ffmpeg). Frames are tagged with a
   1-byte media type so audio and video share one socket; `kind=audio`
   keeps the original untagged raw-PCM wire format unchanged.
-- **`POST /sessions/{sid}/calls/{cid}/transcript`** — local
-  speech-to-text on a call recording via `whisper-rs` (whisper.cpp
-  bindings). Needs `WHISPER_MODEL_PATH` pointed at a GGML model file;
-  the model loads once and is cached for the life of the process. Not
-  a zero-setup feature like the rest of waxum — requires a C++
-  toolchain at build time and a model file at runtime.
+- **`POST /sessions/{sid}/calls/{cid}/transcript`** — forwards a call
+  recording to an external whisper.cpp-compatible HTTP server
+  (`WHISPER_API_URL`) and relays back its `text`. Keeps waxum a
+  pure-Rust single binary with no C++ toolchain or model file baked
+  in — run whisper.cpp (or any compatible server) as its own service,
+  same shape as the existing Edge-TTS integration.
 - Group voice calls stay off the roadmap: `whatsapp-rust` has no
   multi-party relay/SFU support at the library level at all, so this
   isn't implementable as a waxum-side feature without a much larger

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,26 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.13.1",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.3.0",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +584,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -624,15 +604,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -690,17 +661,6 @@ dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout 0.2.2",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1753,12 +1713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,15 +2115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,16 +2250,6 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
 
 [[package]]
 name = "libredox"
@@ -3383,6 +3318,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3391,6 +3327,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3913,12 +3850,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -5124,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5175,7 +5106,6 @@ dependencies = [
  "whatsapp-rust-sqlite-storage",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
- "whisper-rs",
 ]
 
 [[package]]
@@ -5439,28 +5369,6 @@ dependencies = [
  "tokio",
  "ureq",
  "wacore",
-]
-
-[[package]]
-name = "whisper-rs"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
-dependencies = [
- "whisper-rs-sys",
-]
-
-[[package]]
-name = "whisper-rs-sys"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
-dependencies = [
- "bindgen",
- "cfg-if",
- "cmake",
- "fs_extra",
- "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -58,7 +58,11 @@ dashmap = "6"
 once_cell = "1"
 parking_lot = "0.12"
 async-trait = "0.1"
-reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = [
+    "rustls-tls",
+    "multipart",
+    "json",
+], default-features = false }
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 
 # Crypto for webhook signatures
@@ -89,12 +93,6 @@ qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 # directly so `/calls/tts` does not need an external `edge-tts` CLI or
 # Python interpreter installed on the server.
 msedge-tts = "0.4"
-
-# whisper.cpp bindings for local call-recording transcription. Needs a
-# GGML model file at runtime (`WHISPER_MODEL_PATH`) — unlike the rest of
-# waxum this is not a zero-setup feature; see the /calls/*/transcript
-# docs. Compiles whisper.cpp from source (cmake + a C++ toolchain).
-whisper-rs = "0.16"
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Production-grade. **130+ REST endpoints across 22 feature modules.**
 | Peer audio recording (WAV) | `GET /sessions/{sid}/calls/{cid}/recording.wav` |
 | Bidirectional media WebSocket stream (audio) | `WS /sessions/{sid}/calls/media/ws?to=&kind=audio` |
 | Bidirectional media WebSocket stream (audio + video, H.264) | `WS /sessions/{sid}/calls/media/ws?to=&kind=av` — transport only, bring your own H.264 encoder/decoder (e.g. ffmpeg) on the client side |
-| Local transcript of a recording (whisper.cpp) | `POST /sessions/{sid}/calls/{cid}/transcript` — needs `WHISPER_MODEL_PATH` |
+| Transcript of a recording (external whisper.cpp server) | `POST /sessions/{sid}/calls/{cid}/transcript` — needs `WHISPER_API_URL`; waxum stays a pure-Rust single binary, no C++/whisper.cpp is compiled in |
 
 ### Session management
 
@@ -145,7 +145,7 @@ Production-grade. **130+ REST endpoints across 22 feature modules.**
 |---|---|
 | ~~Video call (H.264 relay over `calls/media/ws?kind=av`)~~ | shipped 0.9.0 |
 | Group voice call | **blocked upstream** — `whatsapp-rust` has no multi-party relay/SFU client at all (single-peer engine only); not a waxum gap, needs its own library-level project |
-| ~~Local STT on recording (whisper.cpp)~~ | shipped 0.9.0 — needs `WHISPER_MODEL_PATH` set to a GGML model file, not zero-setup like the rest of waxum |
+| ~~Transcript of a recording~~ | shipped 0.9.1 — calls an external whisper.cpp-compatible HTTP server (`WHISPER_API_URL`), not bundled into the binary |
 | ~~Message search via SQLite FTS~~ | shipped 0.8.0 |
 | ~~Blast queue engine (bulk send, dedup, retry, DLQ)~~ | shipped 0.8.0 |
 | ~~Scheduled send (`send_at` ISO)~~ | shipped 0.8.0 |

--- a/src/handlers/calls.rs
+++ b/src/handlers/calls.rs
@@ -15,8 +15,8 @@ use crate::error::ApiError;
 use crate::handlers::messages::parse_jid;
 use crate::models::calls::{
     AcceptCallRequest, PlayCallRequest, PlayCallResponse, RejectCallRequest, RingCallRequest,
-    RingCallResponse, TerminateCallRequest, TranscriptResponse, TranscriptSegment, TtsCallRequest,
-    TtsCallResponse, VoiceEntry,
+    RingCallResponse, TerminateCallRequest, TranscriptResponse, TtsCallRequest, TtsCallResponse,
+    VoiceEntry,
 };
 use crate::models::common::SuccessResponse;
 use crate::state::{ActiveCallAudio, AppState};
@@ -308,27 +308,6 @@ pub async fn get_recording(
     Ok(r)
 }
 
-/// Read the raw `i16` samples back out of a WAV file written by
-/// [`build_wav_pcm16_mono_16khz`] and convert to the normalised `f32`
-/// PCM whisper.cpp expects. Only understands that exact fixed 44-byte
-/// header shape — this endpoint only ever reads recordings this
-/// process wrote itself, never arbitrary uploaded WAV files.
-fn wav_pcm16_to_f32(bytes: &[u8]) -> Result<Vec<f32>, ApiError> {
-    if bytes.len() < 44 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
-        return Err(ApiError::Internal(
-            "recording is not a valid WAV file".into(),
-        ));
-    }
-    let data_len = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
-    let pcm = bytes
-        .get(44..44 + data_len)
-        .ok_or_else(|| ApiError::Internal("recording WAV data chunk is truncated".into()))?;
-    Ok(pcm
-        .chunks_exact(2)
-        .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
-        .collect())
-}
-
 #[utoipa::path(
     post,
     security(("bearer_auth" = [])),
@@ -341,13 +320,22 @@ fn wav_pcm16_to_f32(bytes: &[u8]) -> Result<Vec<f32>, ApiError> {
     responses(
         (status = 200, description = "Transcript of the call recording", body = TranscriptResponse),
         (status = 404, description = "Recording not found — call hasn't ended or was never recorded"),
-        (status = 500, description = "WHISPER_MODEL_PATH not set, or the model failed to load/run")
+        (status = 500, description = "WHISPER_API_URL not set, or the request to it failed")
     )
 )]
 pub async fn transcribe_call(
     State(state): State<AppState>,
     Path((session_id, call_id)): Path<(String, String)>,
 ) -> Result<Json<TranscriptResponse>, ApiError> {
+    let whisper_url = std::env::var("WHISPER_API_URL").map_err(|_| {
+        ApiError::Internal(
+            "WHISPER_API_URL is not set — point it at an external whisper.cpp-compatible \
+             HTTP server (e.g. the whisper.cpp `server` example, run in its own container) \
+             to enable /calls/*/transcript"
+                .into(),
+        )
+    })?;
+
     let base = state.base_storage_path().to_string();
     let path = std::path::Path::new(&base)
         .join(&session_id)
@@ -358,40 +346,29 @@ pub async fn transcribe_call(
             "recording not found for call {call_id} — wait until the peer hangs up, then retry"
         ))
     })?;
-    let samples = wav_pcm16_to_f32(&bytes)?;
 
-    let ctx = state.whisper_context().await.map_err(ApiError::Internal)?;
-
-    let transcript = tokio::task::spawn_blocking(move || -> Result<TranscriptResponse, String> {
-        let mut whisper_state = ctx.create_state().map_err(|e| e.to_string())?;
-        let mut params =
-            whisper_rs::FullParams::new(whisper_rs::SamplingStrategy::Greedy { best_of: 1 });
-        params.set_print_progress(false);
-        params.set_print_realtime(false);
-        params.set_print_special(false);
-        params.set_print_timestamps(false);
-        whisper_state
-            .full(params, &samples)
-            .map_err(|e| e.to_string())?;
-
-        let segments: Vec<TranscriptSegment> = whisper_state
-            .as_iter()
-            .map(|seg| TranscriptSegment {
-                start_ms: seg.start_timestamp() * 10,
-                end_ms: seg.end_timestamp() * 10,
-                text: seg.to_str_lossy().unwrap_or_default().trim().to_string(),
-            })
-            .collect();
-        let text = segments
-            .iter()
-            .map(|s| s.text.as_str())
-            .collect::<Vec<_>>()
-            .join(" ");
-        Ok(TranscriptResponse { text, segments })
-    })
-    .await
-    .map_err(|e| ApiError::Internal(format!("transcription task panicked: {e}")))?
-    .map_err(ApiError::Internal)?;
+    let form = reqwest::multipart::Form::new().part(
+        "file",
+        reqwest::multipart::Part::bytes(bytes)
+            .file_name(format!("{call_id}.wav"))
+            .mime_str("audio/wav")
+            .map_err(|e| ApiError::Internal(format!("multipart build failed: {e}")))?,
+    );
+    let resp = reqwest::Client::new()
+        .post(&whisper_url)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| ApiError::Internal(format!("whisper server request failed: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(ApiError::Internal(format!(
+            "whisper server returned {}",
+            resp.status()
+        )));
+    }
+    let transcript: TranscriptResponse = resp.json().await.map_err(|e| {
+        ApiError::Internal(format!("whisper server response was not valid JSON: {e}"))
+    })?;
 
     Ok(Json(transcript))
 }
@@ -1333,30 +1310,4 @@ fn voices_response(voices: Vec<VoiceEntry>) -> Result<AxumResponse, ApiError> {
         .header("cache-control", "public, max-age=3600")
         .body(axum::body::Body::from(body))
         .map_err(|e| ApiError::Internal(format!("response build: {e}")))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn wav_pcm16_round_trips_through_build_and_parse() {
-        let samples: Vec<i16> = vec![0, 100, -100, i16::MAX, i16::MIN, 32];
-        let wav = build_wav_pcm16_mono_16khz(&samples);
-        let decoded = wav_pcm16_to_f32(&wav).expect("valid wav");
-        assert_eq!(decoded.len(), samples.len());
-        for (want, got) in samples.iter().zip(decoded.iter()) {
-            let expected = *want as f32 / 32768.0;
-            assert!(
-                (expected - got).abs() < 1e-6,
-                "sample mismatch: want {want} ({expected}), got {got}"
-            );
-        }
-    }
-
-    #[test]
-    fn wav_pcm16_rejects_bad_header() {
-        assert!(wav_pcm16_to_f32(b"not a wav file").is_err());
-        assert!(wav_pcm16_to_f32(&[0u8; 43]).is_err());
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,7 +342,6 @@ use state::AppState;
             models::calls::AcceptCallRequest,
             models::calls::TerminateCallRequest,
             models::calls::TranscriptResponse,
-            models::calls::TranscriptSegment,
 
             models::status::StatusReactionRequest,
 

--- a/src/models/calls.rs
+++ b/src/models/calls.rs
@@ -166,21 +166,12 @@ pub struct VoiceEntry {
     pub friendly_name: Option<String>,
 }
 
-/// Local whisper.cpp transcript of a call recording, returned by
+/// Transcript of a call recording, returned by
 /// `POST /api/v1/sessions/{session_id}/calls/{call_id}/transcript`.
-#[derive(Debug, Clone, Serialize, ToSchema)]
+/// Produced by an external whisper.cpp-compatible HTTP server (see
+/// `WHISPER_API_URL`) — waxum only forwards the recording and relays
+/// the `text` field back, so the shape stays deliberately minimal.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct TranscriptResponse {
-    /// Full transcript, segments joined with a single space.
-    pub text: String,
-    pub segments: Vec<TranscriptSegment>,
-}
-
-/// One whisper.cpp segment. Timestamps are milliseconds from the start
-/// of the recording (whisper.cpp reports centiseconds internally; this
-/// is `* 10`).
-#[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct TranscriptSegment {
-    pub start_ms: i64,
-    pub end_ms: i64,
     pub text: String,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -251,13 +251,6 @@ struct AppStateInner {
     /// and reused after that — the list is stable per Edge-TTS release,
     /// so there is no point re-querying it on every request.
     pub voice_cache: RwLock<Option<Vec<crate::models::calls::VoiceEntry>>>,
-
-    /// Lazily-loaded whisper.cpp model context for call-recording
-    /// transcription, keyed off `WHISPER_MODEL_PATH`. Loaded at most
-    /// once per process — the model file can be tens to hundreds of MB,
-    /// so every `/calls/*/transcript` request after the first reuses
-    /// the same in-memory context instead of reloading it from disk.
-    pub whisper_ctx: tokio::sync::OnceCell<Arc<whisper_rs::WhisperContext>>,
 }
 
 /// A structured event captured from `broadcast_to_webhooks` for both the
@@ -329,7 +322,6 @@ impl AppState {
                 event_ring: parking_lot::Mutex::new(std::collections::VecDeque::with_capacity(200)),
                 session_tags: DashMap::new(),
                 voice_cache: RwLock::new(None),
-                whisper_ctx: tokio::sync::OnceCell::new(),
             }),
         };
 
@@ -503,34 +495,6 @@ impl AppState {
 
     pub fn set_cached_voices(&self, voices: Vec<crate::models::calls::VoiceEntry>) {
         *self.inner.voice_cache.write() = Some(voices);
-    }
-
-    /// Load the whisper.cpp model from `WHISPER_MODEL_PATH` on first use
-    /// and reuse it after that. Loading happens in `spawn_blocking` since
-    /// it involves synchronous file I/O + GGML tensor allocation, which
-    /// can take a noticeable moment for larger models.
-    pub async fn whisper_context(&self) -> Result<Arc<whisper_rs::WhisperContext>, String> {
-        self.inner
-            .whisper_ctx
-            .get_or_try_init(|| async {
-                let path = std::env::var("WHISPER_MODEL_PATH").map_err(|_| {
-                    "WHISPER_MODEL_PATH is not set — point it at a GGML whisper.cpp model file \
-                     (e.g. ggml-base.en.bin) to enable /calls/*/transcript"
-                        .to_string()
-                })?;
-                tokio::task::spawn_blocking(move || {
-                    whisper_rs::WhisperContext::new_with_params(
-                        &path,
-                        whisper_rs::WhisperContextParameters::default(),
-                    )
-                    .map(Arc::new)
-                    .map_err(|e| format!("failed to load whisper model at {path}: {e}"))
-                })
-                .await
-                .map_err(|e| format!("whisper model load task panicked: {e}"))?
-            })
-            .await
-            .cloned()
     }
 
     pub fn incoming_calls(&self) -> &DashMap<String, wacore::types::call::IncomingCall> {


### PR DESCRIPTION
## Summary
- Supersedes the v0.9.0 tag, which was never actually released — its build pulled in `whisper-rs`, which compiles whisper.cpp (C++) directly into the binary and broke the Windows cross-compile job in CI. No binaries or Docker images ever went out under that tag; it's been deleted.
- `/calls/*/transcript` now calls an **external** whisper.cpp-compatible HTTP server (`WHISPER_API_URL`) via multipart POST instead of bundling the model/engine into the binary — same shape as the existing Edge-TTS integration. Waxum stays a pure-Rust single binary with no C++ toolchain required to build it.
- `TranscriptResponse` simplified to `{ text }` (per-segment timestamps only made sense with direct whisper.cpp state access, dropped along with the local engine).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 54 tests passing
- [x] `cargo build`
- [ ] CI: confirm the Windows (`x86_64-pc-windows-gnu`) release build succeeds this time — that's the specific job whisper-rs broke last time