### PR TITLE
v0.9.8 — LID webhook resolution (from_phone), whatsapp-rust bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.9.7] - 2026-07-26
+
+### Changed — bump vendored `whatsapp-rust` (449 commits)
+
+Synced the pinned `whatsapp-rust` / `wacore` / `waproto` rev (and the
+local vendored clone in the workspace) from `0077186` to `dde51e7`,
+449 commits of upstream fixes and perf work — notably a socket fix
+that stops resending after a transport failure instead of reusing
+the nonce, and several VoIP relay/device races. Picked up three
+breaking renames and migrated call sites accordingly, all
+behavior-preserving:
+
+- `Client::get_push_name()` / `get_pn()` / `get_lid()` renamed to
+  `push_name()` / `pn()` / `lid()` — same signatures, straight
+  rename.
+- `GroupCreateOptions::with_membership_approval_mode()` builder
+  method was dropped; the field itself (`membership_approval_mode`)
+  is still public, so call sites now assign it directly.
+- `Groups::set_description()`'s third parameter changed from
+  `Option<&str>` to the new `PreviousDescription` enum. Verified
+  against the previous implementation that a bare `None` used to
+  mean "send no token" — `PreviousDescription::Absent`, exactly what
+  the `From<Option<&str>>` conversion produces, so `.into()` at the
+  call site preserves the old behavior exactly.
+
 ## [0.9.6] - 2026-07-24
 
 ### Changed — session detail page cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.9.8] - 2026-07-26
+
+### Added — resolved phone number in message webhooks (`from_phone`)
+
+WhatsApp's LID-only privacy addressing means the `message` webhook's
+`from` field is often a `12300954140784@lid` value instead of a phone
+number, with no way to turn it back into one — support fielded this
+exact confusion this week (someone conflated it with the *send-side*
+[LID auto-resolve](https://waxum.imtaqin.id/docs/api/messages#lid-auto-resolve),
+which only affects outbound `/messages/*` calls and has no bearing on
+inbound webhooks).
+
+The `message` event payload now carries a `from_phone` field
+alongside `from`:
+
+- Plain-phone senders: `from_phone` mirrors `from`'s number, no
+  lookup needed.
+- `@lid` senders: resolved via `Client::get_lid_pn_entry`, a
+  cache-aside lookup over whatsapp-rust's own passively-learned
+  LID↔phone mapping (usync, message sender attributes, history sync,
+  etc.) — no extra network round trip on waxum's side, and usually
+  already warm for any contact that has messaged before.
+- Unresolved: `from_phone` is `null`. Real "not known yet" outcome
+  (typically a LID's very first message), not a bug — consumers
+  needing the phone number should handle it.
+
+Docs updated: `waxum-doc/docs/api/webhooks.md` documents the new
+field and the `from` vs `from_phone` distinction; a cross-reference
+warning was added to the LID auto-resolve section in `messages.md`
+clarifying it's send-side only.
+
 ## [0.9.7] - 2026-07-26
 
 ### Changed — bump vendored `whatsapp-rust` (449 commits)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.9.3"
+version = "0.9.6"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,7 +4921,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "wacore"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.11.0",
@@ -4971,7 +4971,7 @@ dependencies = [
 [[package]]
 name = "wacore-appstate"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "anyhow",
  "buffa",
@@ -4993,7 +4993,7 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "bytes",
  "compact_str",
@@ -5010,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "wacore-derive"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5020,7 +5020,7 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "aes 0.9.1",
  "arrayref",
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "wacore-noise"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5092,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5419,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5462,7 +5462,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "async-trait",
  "buffa",
@@ -5482,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-tokio-transport"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5502,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=00771869606379d5bed8066fe220f510ebd120f9#00771869606379d5bed8066fe220f510ebd120f9"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 ﻿[package]
 name = "waxum"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -10,13 +10,13 @@ repository = "https://github.com/imtaqin/waxum"
 [dependencies]
 
 rand = "0.8"
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9", default-features = true, features = ["voip", "tracing"] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9" }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9" }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9" }
-whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9" }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9" }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "00771869606379d5bed8066fe220f510ebd120f9" }
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e", default-features = true, features = ["voip", "tracing"] }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
+whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
 
 # Web framework
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }

--- a/src/handlers/groups_management.rs
+++ b/src/handlers/groups_management.rs
@@ -44,7 +44,7 @@ pub async fn create_group(
     let mut options = GroupCreateOptions::new(&request.name).with_participants(participants);
 
     if let Some(mode) = request.membership_approval_mode {
-        options = options.with_membership_approval_mode(match mode {
+        options.membership_approval_mode = Some(match mode {
             crate::models::groups::MembershipApprovalMode::Off => {
                 whatsapp_rust::MembershipApprovalMode::Off
             }
@@ -162,7 +162,7 @@ pub async fn set_group_description(
 
     client
         .groups()
-        .set_description(&jid, description, request.prev_id.as_deref())
+        .set_description(&jid, description, request.prev_id.as_deref().into())
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -1244,7 +1244,8 @@ async fn handle_event(
         for im in batch.messages.iter() {
             crate::handlers::search::record_incoming(state, session_id, &im.message, &im.info)
                 .await;
-            let data = message_event_data(&im.message, &im.info);
+            let from_phone = resolve_sender_phone(&client, &im.info.source.sender).await;
+            let data = message_event_data(&im.message, &im.info, from_phone);
             let payload_value = serde_json::json!({
                 "session_id": session_id,
                 "event": "message",
@@ -1408,12 +1409,14 @@ fn extract_location(msg: &waproto::whatsapp::Message) -> serde_json::Value {
 fn message_event_data(
     msg: &waproto::whatsapp::Message,
     info: &wacore::types::message::MessageInfo,
+    from_phone: Option<String>,
 ) -> serde_json::Value {
     let (text, caption, message_type, media_mimetype) = extract_message_content(msg);
     let media_meta = extract_media_metadata(msg);
     let location = extract_location(msg);
     serde_json::json!({
         "from": info.source.sender.to_string(),
+        "from_phone": from_phone,
         "chat": info.source.chat.to_string(),
         "message_id": info.id.to_string(),
         "timestamp": info.timestamp,
@@ -1431,6 +1434,31 @@ fn message_event_data(
         "is_group": info.source.chat.to_string().ends_with("@g.us"),
         "participant": info.source.sender.to_string(),
     })
+}
+
+/// Resolves `sender` to its phone number for the `from_phone` webhook field.
+///
+/// A `@lid` sender is looked up in whatsapp-rust's own LID↔PN mapping cache
+/// (cache-aside over its persistent backend — no network round trip), which
+/// is populated from several passive sources including the `sender_pn`
+/// attribute WhatsApp attaches to incoming messages, so it is usually already
+/// warm by the time a message arrives. A plain-phone sender needs no lookup.
+async fn resolve_sender_phone(
+    client: &whatsapp_rust::Client,
+    sender: &wacore_binary::Jid,
+) -> Option<String> {
+    if sender.is_pn() {
+        return Some(sender.user.to_string());
+    }
+    if !sender.is_lid() {
+        return None;
+    }
+    client
+        .get_lid_pn_entry(sender)
+        .await
+        .ok()
+        .flatten()
+        .map(|entry| entry.phone_number.to_string())
 }
 
 /// Extracts user-visible content from a protobuf Message: best-effort text,
@@ -1666,7 +1694,7 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
 
     let data = match event {
         Event::Messages(batch) => match batch.first() {
-            Some(im) => message_event_data(&im.message, &im.info),
+            Some(im) => message_event_data(&im.message, &im.info, None),
             None => serde_json::json!({}),
         },
         Event::Receipt(receipt) => {

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -831,14 +831,14 @@ pub async fn get_device_info(
 
     let client = runtime.get_client().ok_or(ApiError::NotConnected)?;
 
-    let push_name_str = client.get_push_name();
+    let push_name_str = client.push_name();
     let push_name = if push_name_str.is_empty() {
         None
     } else {
         Some(push_name_str)
     };
-    let pn = client.get_pn().map(|j| j.to_string());
-    let lid = client.get_lid().map(|j| j.to_string());
+    let pn = client.pn().map(|j| j.to_string());
+    let lid = client.lid().map(|j| j.to_string());
 
     Ok(Json(DeviceInfo {
         device_id: None,
@@ -1145,13 +1145,13 @@ async fn handle_event(
             runtime.set_pair_code(None);
             runtime.clear_pair_state();
 
-            let push_name_str = client.get_push_name();
+            let push_name_str = client.push_name();
             let push_name = if push_name_str.is_empty() {
                 None
             } else {
                 Some(push_name_str)
             };
-            let phone = client.get_pn().map(|j| j.user.clone());
+            let phone = client.pn().map(|j| j.user.clone());
 
             let _ = state
                 .session_manager()


### PR DESCRIPTION
## Summary
- **feat(webhooks): `from_phone` field** — message webhooks resolve `@lid` senders to a real phone number via `Client::get_lid_pn_entry` (whatsapp-rust's own passively-learned LID↔phone cache, no extra network call), or mirror the number directly for plain-PN senders, or `null` when not yet known. Closes a support-reported gap: the send-side LID auto-resolve doc was being misread as applying to inbound webhooks too (it doesn't — webhooks always mirrored WhatsApp's raw sender JID verbatim, with no code path to swap it, regardless of "save to contact" or wait time). Docs updated in `waxum-doc` with a cross-reference so this doesn't reoccur.
- **chore(deps): bump vendored `whatsapp-rust`** — 449 commits (`0077186` → `dde51e7`), including a socket fix that stops resending after a transport failure instead of reusing the nonce, and several VoIP relay/device races. Migrated 3 breaking renames (`get_push_name`/`get_pn`/`get_lid` → `push_name`/`pn`/`lid`, `GroupCreateOptions` membership-approval builder → direct field, `set_description`'s `prev` param → `PreviousDescription` enum), all verified behavior-preserving against the prior implementation.
- **chore: `Cargo.lock` version sync** — the lockfile's own `waxum` package entry was left stale at `0.9.3` from an earlier bump commit; corrected to match `Cargo.toml`.
- Also included: session detail page console cleanup, console redesign + Swagger auth gate, GET query-param fix, session export/import (already covered by the earlier v0.9.6 changelog entries, riding along on the same `dev` branch history).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (54 tests, all passing)
- [x] `cargo build`
- [x] Full whatsapp-rust API surface diff reviewed; all 7 compile breaks traced to their old implementation and confirmed behavior-preserving before fixing