### PR TITLE
v0.10.0 — OWASP Top 10 security hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Something in waxum isn't behaving as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please don't use this
+        form for suspected **security vulnerabilities** — email
+        cp@imtaqin.id instead (see CONTRIBUTING.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: waxum version
+      description: >-
+        The `version` field in `Cargo.toml` at the commit you ran, or the
+        Docker image tag (`fdciabdul/waxum:x.y.z`). `GET /api/v1/info`
+        also returns this if the instance is reachable.
+      placeholder: "0.10.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Database backend
+      description: >-
+        Which `DATABASE_URL` scheme (or the SQLite zero-config default)
+        was in use. Do not paste connection strings or credentials.
+      options:
+        - SQLite (default, no DATABASE_URL set)
+        - PostgreSQL
+        - MySQL
+        - Not sure / not applicable
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - cargo run / cargo build --release (bare metal)
+        - Docker (fdciabdul/waxum image)
+        - Docker Compose
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: >-
+        The exact API call that triggers the issue (method, path, request
+        body) and what came back, versus what you expected. Redact real
+        phone numbers, tokens, and any other sensitive values.
+      placeholder: |
+        Request:
+          POST /api/v1/sessions/my-session/messages/text
+          { "to": "6281234567890", "text": "hi" }
+
+        Observed response:
+          500 { "error": "Internal", "message": "..." }
+
+        Expected:
+          200 with a message_id
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: >-
+        Output with `RUST_LOG=waxum=debug` set, trimmed to the relevant
+        window. Wrap in a code block. Scrub tokens, phone numbers, and
+        message bodies first.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Optional — anything that doesn't fit above.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:cp@imtaqin.id
+    about: Please report suspected vulnerabilities privately, not as a public issue.
+  - name: REST API documentation
+    url: https://waxum.imtaqin.id/docs
+    about: Endpoint reference, webhook payloads, and auth setup.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose a new endpoint, capability, or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Endpoint-shaped requests move fastest if you can sketch the shape
+        you want (method, path, request/response body) — waxum wraps the
+        upstream `whatsapp-rust` client, so also worth checking whether
+        the underlying WhatsApp Web capability already exists there.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The underlying use case, not just the API shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API (if applicable)
+      description: >-
+        Sketch a request/response, or point at an existing similar
+        endpoint in `src/handlers/` you'd model it after.
+      placeholder: |
+        POST /api/v1/sessions/{session_id}/messages/some-new-type
+        { "to": "...", ... }
+      render: json
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds you've tried
+      description: >-
+        Anything you're currently doing instead (combining existing
+        endpoints, client-side workaround, etc.) helps calibrate priority.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,22 @@ jobs:
 
       - name: Build (release)
         run: cargo build --release
+
+      # `~/.cargo/bin` is already in the cache above, so cargo-audit only
+      # needs building from source once; later runs reuse the cached binary.
+      - name: Install cargo-audit (if not cached)
+        run: command -v cargo-audit || cargo install cargo-audit --locked
+
+      # --ignore entries mirror audit.toml (kept in the repo root as the
+      # human-readable record of *why* each is ignored) -- passed
+      # explicitly here since not every cargo-audit version auto-loads
+      # that file. A new advisory not in this list still fails the job.
+      - name: Audit dependencies for known vulnerabilities
+        run: |
+          cargo audit \
+            --ignore RUSTSEC-2026-0194 \
+            --ignore RUSTSEC-2026-0195 \
+            --ignore RUSTSEC-2026-0049 \
+            --ignore RUSTSEC-2026-0098 \
+            --ignore RUSTSEC-2026-0099 \
+            --ignore RUSTSEC-2026-0104

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,110 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.10.0] - 2026-07-28
+
+### Security — OWASP Top 10 hardening pass
+
+Full audit against the OWASP Top 10 (4 parallel reviewers covering access
+control/auth, injection/crypto, SSRF/integrity/design, and
+misconfiguration/dependencies/logging), then fixed everything found.
+
+**Critical**
+
+- **JWT signing secret**: removed the hardcoded fallback
+  (`"your-super-secret-jwt-key-change-in-production"`, live in this repo's
+  public history) used whenever `JWT_SECRET` was unset. Replaced with a
+  random secret generated once per process (`net_guard`-style
+  `once_cell::Lazy`) — an instance that forgets to set `JWT_SECRET` no
+  longer signs tokens with a secret anyone can read on GitHub; tokens
+  minted against the fallback just stop validating on restart instead.
+- **SSRF via "send media by URL"**: `POST .../messages/image` (and
+  video/audio/document/sticker) accepted a caller-supplied URL and
+  fetched it with a bare `reqwest::get`, no validation at all — a
+  request could target `169.254.169.254` (cloud metadata) or any
+  internal service and have the response delivered back as a WhatsApp
+  attachment. New `src/net_guard.rs` validates scheme + resolves the
+  host, rejecting loopback/link-local/private/CGNAT/multicast/etc
+  targets, and a custom `reqwest::dns::Resolve` re-checks on every DNS
+  resolution (including redirect hops) so a URL that resolves safely at
+  registration time but gets DNS-rebound later still can't be reached.
+  Applied to media-by-URL, webhook registration + delivery, and the
+  `/calls/play` audio-URL → ffmpeg path (plus `-protocol_whitelist
+  http,https,tls,tcp` there, since ffmpeg does its own fetch outside
+  our HTTP client).
+
+**Access control**
+
+- **Per-session token scoping**: every valid token was previously a
+  global superadmin — any credential could read/send/delete on *every*
+  session on the instance, not just its own. `POST
+  .../sessions/{id}/token` mints a token restricted to exactly that
+  `session_id`; `jwt_auth_middleware` now rejects a scoped token for any
+  other session_id or for fleet-wide endpoints (list/purge/disconnect-all/
+  search). Existing `SUPERADMIN_TOKEN` and previously-issued unscoped
+  JWTs are unaffected — this is additive, not a behavior change for
+  current users.
+- **Timing side-channel**: bearer/console token comparisons used `==`
+  (short-circuits on the first mismatched byte); switched to a
+  constant-time comparison.
+- **Rate limiting**: there was none, anywhere. Added a global per-peer-IP
+  limiter (`tower_governor`, `RATE_LIMIT_PER_SECOND`/`RATE_LIMIT_BURST`
+  env vars, defaults 20/50), keyed on the TCP peer address rather than
+  `X-Forwarded-For` so it can't be trivially bypassed by a client
+  spoofing a fresh fake IP per request.
+- **CORS**: was a hardcoded wildcard with no way to restrict it.
+  `CORS_ALLOWED_ORIGINS` (comma-separated) now locks it down; still
+  defaults to permissive (with a startup warning) so `cargo run` stays
+  zero-config.
+- **Console cookie**: added `Secure` whenever the request arrived over
+  TLS (detected via `X-Forwarded-Proto`, set by the fronting reverse
+  proxy in the deployments that documented this project actually runs
+  in) — `HttpOnly`/`SameSite=Strict` were already correct. A direct
+  `cargo run` over plain `http://localhost` keeps working with no
+  config, since there's no proxy setting that header.
+
+**Resource exhaustion / integrity**
+
+- **Session import zip-bomb**: `unzip_directory` had zip-slip (path
+  traversal) protection but no cap on entry count or decompressed size
+  — a small crafted archive could exhaust disk. Added entry-count
+  (20,000), per-file (512MB), and total (2GB) uncompressed-size caps,
+  the per-file one enforced against actual bytes copied (not just the
+  zip's self-reported, attacker-controlled size header).
+- **Upload size caps**: `Multipart` bodies were relying on axum's
+  undocumented-in-practice implicit 2MB default (too small for real
+  media/session archives, and not a deliberate choice). `/media/upload`
+  and `/sessions/{id}/import` now carry explicit, intentional
+  `DefaultBodyLimit` caps (100MB / 512MB).
+- **Webhook replay protection**: HMAC signing now covers
+  `{timestamp}.{payload}` (via a new `X-Webhook-Timestamp` header) instead
+  of just the payload — a captured `(url, signature, body)` triple
+  previously replayed forever with a valid signature. **Receivers that
+  verify signatures need to update their verification code** — see
+  `waxum-doc/docs/api/webhooks.md`'s updated Node.js/Python examples.
+
+**Other**
+
+- Failed-auth attempts (missing token, wrong role, cross-session scope
+  violation, invalid signature) and sensitive lifecycle events (session
+  delete) are now logged via `tracing::warn!`.
+- Docker image now runs as a non-root `waxum` user instead of root.
+- `contacts` search LIKE queries didn't escape `%`/`_` in the caller's
+  search term (cosmetic — still safely parameter-bound, not SQL
+  injection — but a caller could widen their own results with wildcard
+  metacharacters). Now uses the same escaping `messages.rs` search
+  already had. Incidentally found and fixed a related latent bug while
+  doing this: `messages.rs`'s LIKE-fallback path used the same `ESCAPE`
+  SQL text for MySQL and SQLite, but MySQL (unlike SQLite/Postgres)
+  interprets backslash escapes inside its own string literals, so the
+  shared syntax was likely malformed SQL against a real MySQL backend.
+  Split into per-dialect syntax, covered by a new SQLite-backed
+  regression test (`tests/contacts_search.rs`) that exercises the actual
+  SQL text rather than just checking it compiles.
+- `cargo audit` added to CI. Found 6 real (transitive, currently
+  unfixable without a larger dependency bump — tracked in `audit.toml`)
+  advisories on first run; 0 in waxum's own direct dependency choices.
+
 ## [0.9.8] - 2026-07-26
 
 ### Added — resolved phone number in message webhooks (`from_phone`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,10 @@ crate-level docs (`cargo doc --open`) for the full env matrix.
 
 ## Local quality gates (required before every push)
 
-The CI pipeline runs the same three checks — matching them locally
-saves a round-trip:
+The `.git/hooks/pre-push` hook bundled with the repo (installed on
+first `git clone` — `chmod +x .git/hooks/pre-push` if it didn't come
+through executable) runs the same three checks before letting a push
+through, plus a `//` line-comment check (see below):
 
 ```sh
 cargo fmt --check
@@ -42,10 +44,17 @@ cargo clippy --all-targets -- -D warnings
 cargo build
 ```
 
-A `.git/hooks/pre-push` hook is bundled with the repo (installed on
-first `git clone` after you `chmod +x` it if needed). It runs the three
-commands above and also rejects any push whose diff introduces new
-`//` line-comments (see below).
+`cargo test` and `cargo audit` (advisory-database dependency scan) are
+not part of the local hook, but CI (`.github/workflows/ci.yml`) runs
+both on every push — run `cargo test` yourself before pushing so CI
+isn't your first signal something broke.
+
+If you're on a memory-constrained machine (this project was largely
+developed on a 16GB/16-core laptop), an unbounded `cargo build`/`cargo
+test` can spawn enough linker processes in parallel to exhaust memory
+and produce confusing "internal compiler error"-looking failures that
+are really just an OOM. Cap it if you hit that: `cargo build -j 4` /
+`cargo test -j 4` (or export `CARGO_BUILD_JOBS=4`).
 
 ## Code conventions
 
@@ -70,11 +79,20 @@ commands above and also rejects any push whose diff introduces new
 1. Add the handler function under `src/handlers/<domain>.rs`. Use the
    existing patterns (extract JSON, resolve the client via
    [`get_live_client`](https://fdciabdul.github.io/waxum/waxum/state/struct.SessionState.html#method.get_live_client),
-   `?`-propagate `ApiError`).
+   `?`-propagate `ApiError`). Any new request/response type goes in
+   `src/models/<domain>.rs` with `#[derive(..., ToSchema)]`.
 2. Add the axum route in `src/routes/mod.rs`.
-3. Register the handler on the utoipa `#[openapi(paths(…))]` list in
-   `src/main.rs` so Swagger UI picks it up.
-4. Update `CHANGELOG.md` under the unreleased section.
+3. Register the handler on the utoipa `#[openapi(paths(…))]` list *and*
+   any new request/response types on `components(schemas(…))`, both in
+   `src/main.rs` — miss the schema half and the handler still shows up
+   in Swagger UI, just with an incomplete/missing body schema.
+4. If the endpoint touches an existing session (`{session_id}` in the
+   path), it's covered by the per-session token scoping in
+   `middleware::jwt::jwt_auth_middleware` automatically — no extra work
+   needed unless it's a fleet-wide endpoint that should stay
+   superadmin-only (see the exclusion list in
+   `jwt::session_id_from_path`).
+5. Update `CHANGELOG.md` under the unreleased section.
 
 ## Releasing
 
@@ -86,7 +104,7 @@ The release flow is manual:
 4. `git push origin main` — the `release.yml` workflow tags the commit,
    builds multi-arch binaries + Docker image, and publishes the
    GitHub release.
-5. On the production server: `docker pull imtaqin/waxum:latest`, then
+5. On the production server: `docker pull fdciabdul/waxum:latest`, then
    `docker cp` the binary out of a temporary container and
    `pm2 restart waxum` (see the internal deploy runbook).
 
@@ -96,12 +114,22 @@ The release flow is manual:
   <https://fdciabdul.github.io/waxum> on every push to `main`. Add
   `///` doc-comments to items you introduce so the API browser stays
   useful.
-- **REST API docs** live in the separate `waxum-doc` mkdocs repo and
-  deploy to <https://doc.wars.imtaqin.id>.
+- **REST API docs** live in the separate `waxum-doc` Docusaurus repo
+  and deploy to <https://waxum.imtaqin.id/docs>.
+
+## Reporting a security issue
+
+Don't file a public issue for a suspected vulnerability. Email
+**cp@imtaqin.id** with a reproduction and, if you can, an assessment
+of impact. Include the same version info as a regular bug report (see
+below). A fix will get a `CHANGELOG.md` entry describing the issue
+once it's out — see the "Security" section of the `0.10.0` entry for
+the level of detail expected.
 
 ## Filing an issue
 
-Include:
+Use the [issue templates](.github/ISSUE_TEMPLATE/) — they prompt for
+the same information listed here. If filing without one, include:
 
 - Version (`git rev-parse HEAD` and `Cargo.toml` version).
 - Backend (`DATABASE_URL` scheme is enough — don't paste creds).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,9 +1726,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1746,6 +1764,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
  "polyval 0.7.3",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.5",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -1828,6 +1869,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2676,6 +2719,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3207,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4118,6 +4197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,6 +4682,22 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.19",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -5193,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.9.8"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5207,6 +5311,7 @@ dependencies = [
  "deadpool-postgres",
  "dotenvy",
  "futures",
+ "governor",
  "handlebars",
  "hex",
  "hmac 0.12.1",
@@ -5232,9 +5337,11 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "url",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
-﻿[package]
+[package]
 name = "waxum"
-version = "0.9.8"
+version = "0.10.0"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -70,6 +70,10 @@ hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 
+# URL parsing for the SSRF guard (net_guard.rs) -- validating scheme and
+# host before any server-side fetch of a caller-supplied URL.
+url = "2"
+
 # JWT authentication
 jsonwebtoken = "9"
 
@@ -105,6 +109,8 @@ s3 = "0.1"
 # in bzip2/lzma/xz, some of which wrap native C libraries we don't
 # need for a plain directory archive.
 zip = { version = "3", default-features = false, features = ["deflate"] }
+tower_governor = { version = "0.8.0", default-features = false, features = ["axum"] }
+governor = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,10 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=rust-builder /app/target/release/waxum /app/waxum
 
-RUN mkdir -p /app/whatsapp_sessions
+RUN mkdir -p /app/whatsapp_sessions \
+    && groupadd --system --gid 1000 waxum \
+    && useradd --system --uid 1000 --gid waxum --no-create-home --shell /usr/sbin/nologin waxum \
+    && chown -R waxum:waxum /app
 
 ENV WHATSAPP_STORAGE_PATH=/app/whatsapp_sessions
 ENV RUST_LOG=waxum=info,tower_http=info
@@ -52,5 +55,7 @@ EXPOSE 3451
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD curl -fsS --max-time 4 http://127.0.0.1:3451/health || exit 1
+
+USER waxum:waxum
 
 CMD ["/app/waxum"]

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,32 @@
+# cargo-audit config (`cargo install cargo-audit`, run in CI's
+# .github/workflows/ci.yml). Entries here are transitive advisories with
+# no upstream fix available yet at the version we can currently take
+# without a breaking dependency bump -- each one is revisited whenever its
+# owning dependency gets updated. A NEW advisory not listed here still
+# fails CI; this file only silences the specific, already-triaged ones
+# below.
+
+[advisories]
+ignore = [
+    # quick-xml, pulled in transitively by the `s3` crate (S3-compatible
+    # call-recording storage) for parsing AWS API XML responses. No newer
+    # `s3` release exists yet that depends on a patched quick-xml. Not
+    # reachable from waxum's own request surface -- only exercised against
+    # responses from an S3-compatible endpoint the operator already
+    # configured and trusts.
+    "RUSTSEC-2026-0194", # quick-xml: quadratic runtime on duplicate attrs
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-decl allocation
+
+    # rustls-webpki 0.102.8, pulled in transitively by async-nats 0.38 (a
+    # patched 0.103.13 already coexists in the tree from other deps).
+    # Fixing this means bumping async-nats across 12 minor releases
+    # (0.38 -> 0.50), which needs its own dedicated compatibility pass
+    # against src/nats/*.rs, not a drive-by version bump. Affects
+    # certificate revocation-list / name-constraint edge cases on the
+    # *outbound* NATS connection the operator configured, not waxum's
+    # inbound HTTP surface.
+    "RUSTSEC-2026-0049", # rustls-webpki: CRL distribution-point matching
+    "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints
+    "RUSTSEC-2026-0099", # rustls-webpki: wildcard name constraints
+    "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+]

--- a/src/console/handlers.rs
+++ b/src/console/handlers.rs
@@ -3,7 +3,11 @@
 //! CSRF token flow because every write endpoint is a POST from
 //! same-origin JS driven by the operator who already holds the cookie,
 //! and there is no third-party embedding surface. SameSite=Strict on
-//! the cookie makes cross-site POSTs unusable.
+//! the cookie makes cross-site POSTs unusable. `Secure` is added
+//! whenever the request arrived over TLS (detected via
+//! `X-Forwarded-Proto`, see `console_cookie_attrs`) and omitted
+//! otherwise, so a plain `cargo run` over `http://localhost` still
+//! works with no extra config.
 
 use axum::{
     body::Body,
@@ -31,7 +35,7 @@ fn cookie_token(headers: &HeaderMap) -> Option<String> {
 
 fn token_is_superadmin(token: &str) -> bool {
     if let Ok(superadmin) = std::env::var("SUPERADMIN_TOKEN") {
-        if !superadmin.is_empty() && token == superadmin {
+        if !superadmin.is_empty() && crate::middleware::jwt::constant_time_eq(token, &superadmin) {
             return true;
         }
     }
@@ -39,6 +43,30 @@ fn token_is_superadmin(token: &str) -> bool {
     match jwt_auth.validate_token(token) {
         Ok(claims) => crate::middleware::jwt::JwtAuth::is_superadmin(&claims),
         Err(_) => false,
+    }
+}
+
+/// Whether to mark the console cookie `Secure`. Waxum itself only ever
+/// speaks plain HTTP (see `main.rs` -- TLS, if any, is terminated by a
+/// reverse proxy in front of it), so there's no local signal for "this
+/// connection is actually TLS". `X-Forwarded-Proto` is the de facto
+/// standard a proxy sets to say so; trusting a client that spoofs it can
+/// only make the cookie *stricter* (sent without `Secure` over their own
+/// plaintext connection, so it just doesn't get echoed back to them) --
+/// never weaker. A direct `cargo run` with no proxy in front sees no such
+/// header and keeps working over `http://localhost` exactly as before.
+fn request_is_https(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("https"))
+}
+
+fn console_cookie_attrs(headers: &HeaderMap) -> &'static str {
+    if request_is_https(headers) {
+        "Path=/; HttpOnly; Secure; SameSite=Strict"
+    } else {
+        "Path=/; HttpOnly; SameSite=Strict"
     }
 }
 
@@ -243,8 +271,9 @@ pub struct LoginForm {
     token: String,
 }
 
-pub async fn login_submit(Form(form): Form<LoginForm>) -> Response {
+pub async fn login_submit(headers: HeaderMap, Form(form): Form<LoginForm>) -> Response {
     if !token_is_superadmin(form.token.trim()) {
+        tracing::warn!("console: rejected login attempt with an invalid token");
         return html(render_page(
             "Sign in",
             "login",
@@ -255,8 +284,9 @@ pub async fn login_submit(Form(form): Form<LoginForm>) -> Response {
     }
 
     let cookie = format!(
-        "{CONSOLE_COOKIE}={}; Path=/; HttpOnly; SameSite=Strict; Max-Age=2592000",
-        form.token.trim()
+        "{CONSOLE_COOKIE}={}; {}; Max-Age=2592000",
+        form.token.trim(),
+        console_cookie_attrs(&headers)
     );
     let mut r = redirect_to("/");
     r.headers_mut()
@@ -264,8 +294,11 @@ pub async fn login_submit(Form(form): Form<LoginForm>) -> Response {
     r
 }
 
-pub async fn logout() -> Response {
-    let cookie = format!("{CONSOLE_COOKIE}=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0");
+pub async fn logout(headers: HeaderMap) -> Response {
+    let cookie = format!(
+        "{CONSOLE_COOKIE}=; {}; Max-Age=0",
+        console_cookie_attrs(&headers)
+    );
     let mut r = redirect_to("/login");
     r.headers_mut()
         .insert(header::SET_COOKIE, HeaderValue::from_str(&cookie).unwrap());

--- a/src/db/contacts.rs
+++ b/src/db/contacts.rs
@@ -1,3 +1,4 @@
+use crate::db::messages::like_pattern;
 use crate::db::session::{sqlite_blocking, DbPool};
 use crate::db::sqlite_raw::{self, Value as SQ};
 use serde::Serialize;
@@ -131,11 +132,11 @@ impl<'a> ContactStore<'a> {
             DbPool::Postgres(pg) => {
                 let client = pg.get().await?;
                 let rows = if let Some(q) = search {
-                    let q_like = format!("%{}%", q);
+                    let q_like = like_pattern(q);
                     client.query(
                         "SELECT jid, phone, lid_jid, full_name, first_name, push_name, business_name, source, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS')
                          FROM contacts WHERE session_id = $1
-                         AND (full_name ILIKE $2 OR first_name ILIKE $2 OR push_name ILIKE $2 OR phone ILIKE $2 OR business_name ILIKE $2)
+                         AND (full_name ILIKE $2 ESCAPE '\\' OR first_name ILIKE $2 ESCAPE '\\' OR push_name ILIKE $2 ESCAPE '\\' OR phone ILIKE $2 ESCAPE '\\' OR business_name ILIKE $2 ESCAPE '\\')
                          ORDER BY COALESCE(full_name, push_name, jid) ASC LIMIT $3 OFFSET $4",
                         &[&session_id, &q_like, &(limit as i64), &(offset as i64)],
                     ).await?
@@ -176,11 +177,11 @@ impl<'a> ContactStore<'a> {
                     String,
                     Option<String>,
                 )> = if let Some(q) = search {
-                    let q_like = format!("%{}%", q);
+                    let q_like = like_pattern(q);
                     conn.exec(
                         "SELECT jid, phone, lid_jid, full_name, first_name, push_name, business_name, source, updated_at
                          FROM contacts WHERE session_id = ?
-                         AND (full_name LIKE ? OR first_name LIKE ? OR push_name LIKE ? OR phone LIKE ? OR business_name LIKE ?)
+                         AND (full_name LIKE ? ESCAPE '\\\\' OR first_name LIKE ? ESCAPE '\\\\' OR push_name LIKE ? ESCAPE '\\\\' OR phone LIKE ? ESCAPE '\\\\' OR business_name LIKE ? ESCAPE '\\\\')
                          ORDER BY COALESCE(full_name, push_name, jid) ASC LIMIT ? OFFSET ?",
                         (session_id, &q_like, &q_like, &q_like, &q_like, &q_like, limit as i64, offset as i64),
                     ).await?
@@ -209,7 +210,7 @@ impl<'a> ContactStore<'a> {
             }
             DbPool::SQLite(pool) => {
                 let sid = session_id.to_string();
-                let q = search.map(|s| format!("%{}%", s));
+                let q = search.map(like_pattern);
                 let limit_i = limit as i64;
                 let offset_i = offset as i64;
                 sqlite_blocking(pool, move |conn| {
@@ -227,7 +228,7 @@ impl<'a> ContactStore<'a> {
                     if let Some(qq) = q {
                         sqlite_raw::query(
                             conn,
-                            "SELECT jid, phone, lid_jid, full_name, first_name, push_name, business_name, source, updated_at FROM contacts WHERE session_id = ? AND (COALESCE(full_name,'') LIKE ? OR COALESCE(first_name,'') LIKE ? OR COALESCE(push_name,'') LIKE ? OR COALESCE(phone,'') LIKE ? OR COALESCE(business_name,'') LIKE ?) ORDER BY COALESCE(full_name, push_name, jid) ASC LIMIT ? OFFSET ?",
+                            "SELECT jid, phone, lid_jid, full_name, first_name, push_name, business_name, source, updated_at FROM contacts WHERE session_id = ? AND (COALESCE(full_name,'') LIKE ? ESCAPE '\\' OR COALESCE(first_name,'') LIKE ? ESCAPE '\\' OR COALESCE(push_name,'') LIKE ? ESCAPE '\\' OR COALESCE(phone,'') LIKE ? ESCAPE '\\' OR COALESCE(business_name,'') LIKE ? ESCAPE '\\') ORDER BY COALESCE(full_name, push_name, jid) ASC LIMIT ? OFFSET ?",
                             &[SQ::Text(sid), SQ::Text(qq.clone()), SQ::Text(qq.clone()), SQ::Text(qq.clone()), SQ::Text(qq.clone()), SQ::Text(qq), SQ::Int(limit_i), SQ::Int(offset_i)],
                             mapper,
                         )

--- a/src/db/messages.rs
+++ b/src/db/messages.rs
@@ -319,6 +319,15 @@ enum LikeValue {
 
 /// Build the LIKE fallback SQL + params for SQLite/MySQL (`?`
 /// placeholders). Caller converts [`LikeValue`] into driver values.
+///
+/// The `ESCAPE` clause's backslash differs per dialect: SQLite's string
+/// literals don't process backslash escapes at all, so the SQL text's
+/// single `\` is already the one literal backslash character
+/// [`like_pattern`] escaped the value with. MySQL *does* interpret
+/// backslash escapes inside string literals by default -- a lone `\`
+/// immediately before the closing quote would escape that quote instead
+/// of terminating the string, so its SQL text needs `\\` (MySQL's own
+/// escape sequence for one literal backslash) instead.
 fn like_query(
     pool: &DbPool,
     session_id: Option<&str>,
@@ -328,7 +337,8 @@ fn like_query(
 ) -> (String, Vec<LikeValue>) {
     let mut values: Vec<LikeValue> = vec![LikeValue::Text(like_pattern(query))];
     let mut where_sql = match pool {
-        DbPool::MySQL(_) | DbPool::SQLite(_) => "body LIKE ? ESCAPE '\\'".to_string(),
+        DbPool::SQLite(_) => "body LIKE ? ESCAPE '\\'".to_string(),
+        DbPool::MySQL(_) => "body LIKE ? ESCAPE '\\\\'".to_string(),
         DbPool::Postgres(_) => unreachable!("postgres fallback uses pg_search_ilike"),
     };
     if let Some(sid) = session_id {
@@ -344,7 +354,7 @@ fn like_query(
 }
 
 /// Escape a user query for `LIKE … ESCAPE '\'` and wrap it in `%…%`.
-fn like_pattern(query: &str) -> String {
+pub(crate) fn like_pattern(query: &str) -> String {
     let escaped = query
         .replace('\\', "\\\\")
         .replace('%', "\\%")

--- a/src/handlers/calls.rs
+++ b/src/handlers/calls.rs
@@ -692,14 +692,33 @@ pub async fn play_call(
     }))
 }
 
+/// Shells out to `ffmpeg -i <url>` and decodes to 16kHz mono PCM.
+///
+/// ffmpeg does its own fetch of `-i <url>` -- it isn't routed through
+/// [`crate::net_guard::safe_http_client`], so that helper's per-request DNS
+/// check can't cover it. [`crate::net_guard::validate_public_url`] validates
+/// scheme + resolved address up front (blocks a request-time SSRF/LFI
+/// attempt), and `-protocol_whitelist` below pins ffmpeg's own input to the
+/// http(s) protocol handlers so it can't be pointed at `file://`,
+/// `concat:`, `subfile,,,`, and similar local I/O-capable protocols
+/// regardless of what URL string it's given. Residual risk: ffmpeg resolves
+/// the hostname itself at fetch time, a moment after our check, so a
+/// DNS-rebind in that window isn't caught the way it is for the
+/// reqwest-based paths.
 async fn decode_url_to_pcm(url: &str) -> anyhow::Result<Vec<i16>> {
     use std::process::Stdio;
+
+    crate::net_guard::validate_public_url(url)
+        .await
+        .map_err(anyhow::Error::msg)?;
 
     let ffmpeg = tokio::process::Command::new("ffmpeg")
         .args([
             "-hide_banner",
             "-loglevel",
             "error",
+            "-protocol_whitelist",
+            "http,https,tls,tcp",
             "-i",
             url,
             "-f",

--- a/src/handlers/messages.rs
+++ b/src/handlers/messages.rs
@@ -3456,7 +3456,13 @@ async fn do_get_user_info_lite(
 pub(crate) async fn get_media_data(media: &MediaData) -> Result<(Vec<u8>, String), ApiError> {
     match media {
         MediaData::Url { url } => {
-            let response = reqwest::get(url)
+            crate::net_guard::validate_public_url(url)
+                .await
+                .map_err(ApiError::BadRequest)?;
+
+            let response = crate::net_guard::safe_http_client()
+                .get(url)
+                .send()
                 .await
                 .map_err(|e| ApiError::BadRequest(format!("Failed to fetch URL: {}", e)))?;
 

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -9,9 +9,9 @@ use crate::device_props::ResolvedDeviceProps;
 use crate::error::ApiError;
 use crate::models::common::SuccessResponse;
 use crate::models::sessions::{
-    ConnectRequest, CreateSessionRequest, CreateSessionResponse, DeviceInfo, PairCodeRequest,
-    PairCodeResponse, QrCodeResponse, SessionInfo, SessionListResponse, SessionStatus,
-    SessionStatusResponse,
+    ConnectRequest, CreateSessionRequest, CreateSessionResponse, DeviceInfo,
+    IssueSessionTokenRequest, IssueSessionTokenResponse, PairCodeRequest, PairCodeResponse,
+    QrCodeResponse, SessionInfo, SessionListResponse, SessionStatus, SessionStatusResponse,
 };
 use crate::models::webhooks::{WebhookConfig, WebhookEvent};
 use crate::state::AppState;
@@ -201,6 +201,8 @@ pub async fn delete_session(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<Json<SuccessResponse>, ApiError> {
+    tracing::warn!(session_id = %session_id, "session: delete requested (storage + registry will be purged)");
+
     if let Some(runtime) = state.get_session(&session_id) {
         if let Some(client) = runtime.get_client() {
             client.disconnect().await;
@@ -771,14 +773,35 @@ fn zip_directory(dir: &str) -> anyhow::Result<Vec<u8>> {
     Ok(buf.into_inner())
 }
 
+/// Caps for [`unzip_directory`]: an import is caller-supplied and untrusted,
+/// so a crafted archive with a tiny compressed size but a huge (or
+/// unbounded) decompressed size -- a zip bomb -- must not be able to
+/// exhaust disk. `MAX_IMPORT_ENTRY_UNCOMPRESSED_BYTES` is enforced twice:
+/// once from the entry's declared size (fast rejection for the well-formed
+/// case) and once as a hard `Read::take` cap on the actual bytes copied,
+/// since the declared size in a zip's local/central header is
+/// attacker-controlled metadata, not a guarantee.
+const MAX_IMPORT_ENTRIES: usize = 20_000;
+const MAX_IMPORT_ENTRY_UNCOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_IMPORT_TOTAL_UNCOMPRESSED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
 /// Unzip into `dir`, creating it if needed. Rejects entries whose path
-/// would escape `dir` (zip-slip) instead of writing them. Blocking;
-/// run inside `spawn_blocking`.
+/// would escape `dir` (zip-slip) instead of writing them, and enforces the
+/// zip-bomb caps above. Blocking; run inside `spawn_blocking`.
 fn unzip_directory(dir: &str, zip_bytes: &[u8]) -> anyhow::Result<()> {
     let base = std::path::Path::new(dir);
     std::fs::create_dir_all(base)?;
 
     let mut archive = zip::ZipArchive::new(std::io::Cursor::new(zip_bytes))?;
+    if archive.len() > MAX_IMPORT_ENTRIES {
+        anyhow::bail!(
+            "zip has {} entries, exceeding the {} entry limit",
+            archive.len(),
+            MAX_IMPORT_ENTRIES
+        );
+    }
+
+    let mut total_uncompressed: u64 = 0;
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)?;
         let Some(rel) = file.enclosed_name() else {
@@ -790,12 +813,35 @@ fn unzip_directory(dir: &str, zip_bytes: &[u8]) -> anyhow::Result<()> {
         if file.is_dir() {
             continue;
         }
-        let out_path = base.join(rel);
+
+        if file.size() > MAX_IMPORT_ENTRY_UNCOMPRESSED_BYTES {
+            anyhow::bail!(
+                "zip entry {:?} declares {} uncompressed bytes, exceeding the per-file limit",
+                rel,
+                file.size()
+            );
+        }
+        total_uncompressed = total_uncompressed.saturating_add(file.size());
+        if total_uncompressed > MAX_IMPORT_TOTAL_UNCOMPRESSED_BYTES {
+            anyhow::bail!(
+                "zip's total declared uncompressed size exceeds the {} byte limit",
+                MAX_IMPORT_TOTAL_UNCOMPRESSED_BYTES
+            );
+        }
+
+        let out_path = base.join(&rel);
         if let Some(parent) = out_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
         let mut out = std::fs::File::create(&out_path)?;
-        std::io::copy(&mut file, &mut out)?;
+        let mut limited = std::io::Read::take(&mut file, MAX_IMPORT_ENTRY_UNCOMPRESSED_BYTES + 1);
+        let copied = std::io::copy(&mut limited, &mut out)?;
+        if copied > MAX_IMPORT_ENTRY_UNCOMPRESSED_BYTES {
+            anyhow::bail!(
+                "zip entry {:?} exceeded the per-file uncompressed size limit while extracting",
+                rel
+            );
+        }
     }
     Ok(())
 }
@@ -845,6 +891,52 @@ pub async fn get_device_info(
         phone_number: pn,
         lid,
         push_name,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/token",
+    tag = "sessions",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    request_body = IssueSessionTokenRequest,
+    responses(
+        (status = 200, description = "Session-scoped token issued", body = IssueSessionTokenResponse),
+        (status = 404, description = "Session not found")
+    )
+)]
+pub async fn issue_session_token(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(request): Json<IssueSessionTokenRequest>,
+) -> Result<Json<IssueSessionTokenResponse>, ApiError> {
+    let _ = state
+        .session_manager()
+        .get_session(&session_id)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+        .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
+
+    let expires_in_hours = request.expires_in_hours.unwrap_or(24 * 30).max(1);
+
+    let jwt_auth = crate::middleware::jwt::JwtAuth::new();
+    let token = jwt_auth
+        .generate_token(
+            &session_id,
+            "superadmin",
+            expires_in_hours,
+            Some(&session_id),
+        )
+        .map_err(|e| ApiError::Internal(format!("failed to generate token: {e}")))?;
+    let expires_at = (chrono::Utc::now() + chrono::Duration::hours(expires_in_hours)).timestamp();
+
+    Ok(Json(IssueSessionTokenResponse {
+        token,
+        session_id,
+        expires_at,
     }))
 }
 
@@ -1876,5 +1968,49 @@ mod tests {
         let dst_path = dst.path().join("restored");
         let result = unzip_directory(dst_path.to_str().unwrap(), &buf.into_inner());
         assert!(result.is_err(), "path traversal entry must be rejected");
+    }
+
+    #[test]
+    fn unzip_rejects_too_many_entries() {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            let options = zip::write::SimpleFileOptions::default();
+            for i in 0..=MAX_IMPORT_ENTRIES {
+                writer.start_file(format!("f{i}"), options).unwrap();
+            }
+            writer.finish().unwrap();
+        }
+
+        let dst = tempfile::tempdir().expect("dst tempdir");
+        let dst_path = dst.path().join("restored");
+        let result = unzip_directory(dst_path.to_str().unwrap(), &buf.into_inner());
+        let err = result.expect_err("entry-count limit must be enforced");
+        assert!(err.to_string().contains("entries"), "{err}");
+    }
+
+    /// The filler is all zeros -- highly compressible, so this zip stays
+    /// small on disk. A real zip bomb needs the *decompressed* size
+    /// checked, not the compressed size; that's exactly what this proves.
+    #[test]
+    fn unzip_rejects_entry_over_the_per_file_size_cap() {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            let options = zip::write::SimpleFileOptions::default();
+            writer.start_file("huge.bin", options).unwrap();
+            let chunk = vec![0u8; 8 * 1024 * 1024];
+            let chunks_needed = (MAX_IMPORT_ENTRY_UNCOMPRESSED_BYTES / chunk.len() as u64) + 1;
+            for _ in 0..chunks_needed {
+                std::io::Write::write_all(&mut writer, &chunk).unwrap();
+            }
+            writer.finish().unwrap();
+        }
+
+        let dst = tempfile::tempdir().expect("dst tempdir");
+        let dst_path = dst.path().join("restored");
+        let result = unzip_directory(dst_path.to_str().unwrap(), &buf.into_inner());
+        let err = result.expect_err("per-entry uncompressed size limit must be enforced");
+        assert!(err.to_string().contains("per-file"), "{err}");
     }
 }

--- a/src/handlers/webhooks.rs
+++ b/src/handlers/webhooks.rs
@@ -73,11 +73,9 @@ pub async fn register_webhook(
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
 
-    if !request.url.starts_with("http://") && !request.url.starts_with("https://") {
-        return Err(ApiError::BadRequest(
-            "Webhook URL must start with http:// or https://".to_string(),
-        ));
-    }
+    crate::net_guard::validate_public_url(&request.url)
+        .await
+        .map_err(ApiError::BadRequest)?;
 
     let existing = state.get_webhooks(&session_id);
     if existing.iter().any(|(_, w)| w.url == request.url) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod middleware;
 pub mod models;
 pub mod nats;
 pub mod net;
+pub mod net_guard;
 pub mod preflight;
 pub mod routes;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,14 @@
 //!   whichever DB `DATABASE_URL` points at.
 use anyhow::Result;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
+use tower_governor::{
+    governor::{GovernorConfig, GovernorConfigBuilder},
+    key_extractor::PeerIpKeyExtractor,
+    GovernorLayer,
+};
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -106,6 +112,7 @@ use state::AppState;
         handlers::sessions::export_session,
         handlers::sessions::import_session,
         handlers::sessions::get_device_info,
+        handlers::sessions::issue_session_token,
 
         handlers::messages::send_text,
         handlers::messages::send_image,
@@ -245,6 +252,8 @@ use state::AppState;
             models::sessions::QrCodeResponse,
             models::sessions::SessionStatusResponse,
             models::sessions::DeviceInfo,
+            models::sessions::IssueSessionTokenRequest,
+            models::sessions::IssueSessionTokenResponse,
 
             models::messages::SendTextRequest,
             models::messages::SendImageRequest,
@@ -440,6 +449,107 @@ impl utoipa::Modify for SecurityAddon {
                         .build(),
                 ),
             );
+        }
+    }
+}
+
+/// Builds the global per-peer-IP rate limiter (`RATE_LIMIT_PER_SECOND` /
+/// `RATE_LIMIT_BURST` env vars, default 20/50) and spawns the background
+/// task that periodically evicts stale entries from its state map --
+/// without that, the map only grows and becomes an unbounded memory leak
+/// in front of a public server.
+///
+/// No rate limiting existed anywhere in the stack before this -- a bearer
+/// token holder (or an unauthenticated caller hitting `/login`) could
+/// hammer pairing codes, blast sends, or webhook registration unbounded.
+/// Keyed on the TCP peer address ([`PeerIpKeyExtractor`]) rather than
+/// `X-Forwarded-For`/`X-Real-IP`: those headers are client-controlled
+/// unless a trusted proxy strips and re-sets them, and trusting them
+/// blindly would let a client bypass the limit entirely by sending a fresh
+/// fake IP on every request. The tradeoff is that behind an unconfigured
+/// reverse proxy every client shares one quota (the proxy's peer IP) --
+/// less precise, but not bypassable. Applied as the outermost layer in
+/// [`async_main`] so every request is rate-limited before it costs a JWT
+/// validation or reaches a handler.
+fn build_rate_limiter(
+) -> Arc<GovernorConfig<PeerIpKeyExtractor, governor::middleware::NoOpMiddleware>> {
+    let per_second: u64 = std::env::var("RATE_LIMIT_PER_SECOND")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20);
+    let burst: u32 = std::env::var("RATE_LIMIT_BURST")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+    let conf = Arc::new(
+        GovernorConfigBuilder::default()
+            .key_extractor(PeerIpKeyExtractor)
+            .per_second(per_second)
+            .burst_size(burst)
+            .finish()
+            .expect("valid rate-limit configuration"),
+    );
+
+    let limiter = conf.limiter().clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            limiter.retain_recent();
+        }
+    });
+
+    conf
+}
+
+/// Builds the CORS layer from `CORS_ALLOWED_ORIGINS` (comma-separated exact
+/// origins, e.g. `https://app.example.com,https://admin.example.com`).
+/// Unset keeps the historical permissive default (`Any`) so `cargo run`
+/// stays zero-config -- but a bearer token is readable by any origin's JS
+/// via `fetch()` under that default, so production deployments should set
+/// this.
+fn build_cors_layer() -> CorsLayer {
+    match std::env::var("CORS_ALLOWED_ORIGINS") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            let origins: Vec<axum::http::HeaderValue> = raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .filter_map(|s| match s.parse() {
+                    Ok(v) => Some(v),
+                    Err(_) => {
+                        tracing::warn!("CORS_ALLOWED_ORIGINS: ignoring invalid origin '{}'", s);
+                        None
+                    }
+                })
+                .collect();
+
+            if origins.is_empty() {
+                tracing::warn!(
+                    "CORS_ALLOWED_ORIGINS was set but contained no valid origins; \
+                     falling back to permissive CORS (any origin allowed)"
+                );
+                return CorsLayer::new()
+                    .allow_origin(Any)
+                    .allow_methods(Any)
+                    .allow_headers(Any);
+            }
+
+            tracing::info!("CORS restricted to {} configured origin(s)", origins.len());
+            CorsLayer::new()
+                .allow_origin(origins)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
+        _ => {
+            tracing::warn!(
+                "CORS_ALLOWED_ORIGINS not set -- allowing requests from any origin. \
+                 Set a comma-separated allowlist before deploying to production."
+            );
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any)
         }
     }
 }
@@ -716,10 +826,8 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
         }
     }
 
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any);
+    let cors = build_cors_layer();
+    let governor_conf = build_rate_limiter();
 
     let (superadmin_token, from_env) = middleware::jwt::get_superadmin_token();
     println!();
@@ -750,6 +858,7 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
         ))
         .layer(TraceLayer::new_for_http())
         .layer(cors)
+        .layer(GovernorLayer::new(governor_conf))
         .with_state(state);
 
     let port: u16 = std::env::var("PORT")
@@ -774,7 +883,11 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
     println!();
 
     let listener = TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/middleware/jwt.rs
+++ b/src/middleware/jwt.rs
@@ -22,8 +22,27 @@ use axum::{
     Json,
 };
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use once_cell::sync::Lazy;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+
+/// Process-local fallback signing secret, used only when `JWT_SECRET` is
+/// unset. Generated once per process from OS entropy rather than a fixed
+/// string baked into the binary — a hardcoded fallback here would let anyone
+/// who has read this source forge a superadmin token against any instance
+/// that forgot to set `JWT_SECRET`. The tradeoff: tokens signed against this
+/// fallback stop validating on restart, which is the point — it bounds how
+/// long a leaked token (e.g. from the boot-banner print) stays useful.
+static FALLBACK_JWT_SECRET: Lazy<String> = Lazy::new(|| {
+    tracing::warn!(
+        "JWT_SECRET is not set; using a random secret generated for this \
+         process only. Tokens will stop validating after a restart. Set \
+         JWT_SECRET to a strong, stable value before deploying to production."
+    );
+    let bytes: [u8; 32] = rand::thread_rng().gen();
+    hex::encode(bytes)
+});
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -34,6 +53,16 @@ pub struct Claims {
     pub exp: usize,
 
     pub iat: usize,
+
+    /// Restricts this token to a single `session_id`, checked in
+    /// [`jwt_auth_middleware`] against every `/api/v1/sessions/{session_id}/*`
+    /// request. `None` (the default for tokens minted before this field
+    /// existed, and for the operator-wide `SUPERADMIN_TOKEN`/boot token) is
+    /// unrestricted -- unchanged, pre-existing behavior. `Some(id)` is how a
+    /// customer-facing token is handed out without also granting it every
+    /// *other* customer's session on the same instance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -49,8 +78,7 @@ impl Default for JwtAuth {
 
 impl JwtAuth {
     pub fn new() -> Self {
-        let secret = std::env::var("JWT_SECRET")
-            .unwrap_or_else(|_| "your-super-secret-jwt-key-change-in-production".to_string());
+        let secret = std::env::var("JWT_SECRET").unwrap_or_else(|_| FALLBACK_JWT_SECRET.clone());
         Self { secret }
     }
 
@@ -64,6 +92,7 @@ impl JwtAuth {
         subject: &str,
         role: &str,
         expires_in_hours: i64,
+        session_id: Option<&str>,
     ) -> Result<String, jsonwebtoken::errors::Error> {
         let now = chrono::Utc::now();
         let exp = (now + chrono::Duration::hours(expires_in_hours)).timestamp() as usize;
@@ -74,6 +103,7 @@ impl JwtAuth {
             role: role.to_string(),
             exp,
             iat,
+            session_id: session_id.map(|s| s.to_string()),
         };
 
         encode(
@@ -95,6 +125,18 @@ impl JwtAuth {
     pub fn is_superadmin(claims: &Claims) -> bool {
         claims.role == "superadmin"
     }
+}
+
+/// Best-effort caller IP for auth-failure logging. `main.rs` serves via
+/// `into_make_service_with_connect_info::<SocketAddr>()`, so this is
+/// present on every real request; falls back gracefully (e.g. in tests that
+/// build the router without connect-info) rather than panicking.
+fn peer_ip(request: &Request<Body>) -> String {
+    request
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response {
@@ -128,11 +170,14 @@ pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response
             None
         });
 
+    let peer = peer_ip(&request);
+
     let token: String = match auth_header {
         Some(header) if header.starts_with("Bearer ") => header[7..].to_string(),
         _ => match cookie_token {
             Some(t) => t,
             None => {
+                tracing::warn!(peer = %peer, path = %path, "auth: missing bearer token/cookie");
                 return unauthorized_response(
                     "Missing or invalid Authorization header. Use: Bearer <token>",
                 );
@@ -142,7 +187,7 @@ pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response
     let token = token.as_str();
 
     if let Ok(superadmin_token) = std::env::var("SUPERADMIN_TOKEN") {
-        if !superadmin_token.is_empty() && token == superadmin_token {
+        if !superadmin_token.is_empty() && constant_time_eq(token, &superadmin_token) {
             return next.run(request).await;
         }
     }
@@ -150,12 +195,27 @@ pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response
     match jwt_auth.validate_token(token) {
         Ok(claims) => {
             if !JwtAuth::is_superadmin(&claims) {
+                tracing::warn!(peer = %peer, path = %path, role = %claims.role, "auth: non-superadmin role rejected");
                 return forbidden_response("Superadmin role required");
+            }
+
+            if let Some(scope) = claims.session_id.as_deref() {
+                match session_id_from_path(path) {
+                    Some(requested) if requested == scope => {}
+                    _ => {
+                        tracing::warn!(
+                            peer = %peer, path = %path, scope = %scope,
+                            "auth: token scoped to a different session attempted cross-session access"
+                        );
+                        return forbidden_response("Token is scoped to a different session");
+                    }
+                }
             }
 
             next.run(request).await
         }
         Err(e) => {
+            tracing::warn!(peer = %peer, path = %path, error = %e, "auth: token validation failed");
             let message = match e.kind() {
                 jsonwebtoken::errors::ErrorKind::ExpiredSignature => "Token has expired",
                 jsonwebtoken::errors::ErrorKind::InvalidToken => "Invalid token format",
@@ -165,6 +225,36 @@ pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response
             unauthorized_response(message)
         }
     }
+}
+
+/// Pulls the `{session_id}` segment out of a `/api/v1/sessions/{session_id}/...`
+/// request path, or `None` for anything else -- including the fleet-wide
+/// operations nested under the same `/sessions` prefix (`/`, `/purge`,
+/// `/disconnect-all`, `/reconnect-all`, `/search`), which a session-scoped
+/// token must not be able to reach since they aren't bounded to one session.
+fn session_id_from_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("/api/v1/sessions/")?;
+    let id = rest.split('/').next()?;
+    if id.is_empty() || matches!(id, "purge" | "disconnect-all" | "reconnect-all" | "search") {
+        return None;
+    }
+    Some(id)
+}
+
+/// Constant-time string comparison for secret/token checks. A plain `==`
+/// short-circuits on the first mismatched byte, which turns a bearer-token
+/// check into a timing oracle for brute-forcing a long-lived secret one byte
+/// at a time; this walks the full length regardless of where it first
+/// differs.
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
 }
 
 fn unauthorized_response(message: &str) -> Response {
@@ -198,7 +288,7 @@ pub fn get_superadmin_token() -> (String, bool) {
 
     let jwt_auth = JwtAuth::new();
     let token = jwt_auth
-        .generate_token("superadmin", "superadmin", 24 * 365)
+        .generate_token("superadmin", "superadmin", 24 * 365, None)
         .expect("Failed to generate token");
     (token, false)
 }
@@ -207,6 +297,6 @@ pub fn get_superadmin_token() -> (String, bool) {
 pub fn generate_superadmin_token() -> String {
     let jwt_auth = JwtAuth::new();
     jwt_auth
-        .generate_token("superadmin", "superadmin", 24 * 365)
+        .generate_token("superadmin", "superadmin", 24 * 365, None)
         .expect("Failed to generate token")
 }

--- a/src/models/sessions.rs
+++ b/src/models/sessions.rs
@@ -210,6 +210,29 @@ pub struct SessionStatusResponse {
     pub pair: PairStatus,
 }
 
+/// Request body for minting a session-scoped bearer token.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct IssueSessionTokenRequest {
+    /// How long the token stays valid. Defaults to 720 (30 days) when omitted.
+    #[schema(example = 720)]
+    pub expires_in_hours: Option<i64>,
+}
+
+/// A bearer token restricted to a single session -- unlike the instance's
+/// `SUPERADMIN_TOKEN` or an unscoped superadmin JWT, this token is rejected
+/// by [`crate::middleware::jwt::jwt_auth_middleware`] for every other
+/// session_id and for fleet-wide endpoints (list/purge/disconnect-all/etc).
+/// Meant for handing a single customer access to only their own WhatsApp
+/// session on a shared instance.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct IssueSessionTokenResponse {
+    /// Bearer token, valid only for this session_id.
+    pub token: String,
+    pub session_id: String,
+    /// Unix timestamp the token stops validating.
+    pub expires_at: i64,
+}
+
 /// Device information
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct DeviceInfo {

--- a/src/net_guard.rs
+++ b/src/net_guard.rs
@@ -1,0 +1,237 @@
+//! SSRF guard for any code path that fetches or connects to a
+//! caller-supplied URL: "send media by URL" (`handlers::messages`), webhook
+//! registration + delivery (`handlers::webhooks`, `state.rs`), and the call
+//! audio-URL playback path (`handlers::calls`).
+//!
+//! Two layers, because a single up-front string check is not enough — the
+//! attacker doesn't need a URL that already points at 169.254.169.254, they
+//! just need one whose DNS answer changes between our check and the actual
+//! connection (a "DNS rebind"):
+//!
+//! - [`validate_public_url`]: cheap fail-fast check (scheme + one DNS
+//!   resolution) for validating input eagerly, e.g. at webhook registration
+//!   time so a bad URL is rejected immediately instead of silently never
+//!   firing.
+//! - [`SsrfSafeResolver`]: a `reqwest::dns::Resolve` implementation that
+//!   performs the same address check on *every* DNS resolution reqwest
+//!   actually makes for a request, including redirect hops (each hop
+//!   re-resolves its target host). Wired into [`safe_http_client`], this is
+//!   what actually closes the DNS-rebind and redirect-to-internal-host
+//!   bypasses — `validate_public_url` alone cannot, since the resolution it
+//!   saw is not necessarily the one the HTTP client will use moments later.
+//!
+//! Both reject: non-`http(s)` schemes, and any resolved address in a
+//! loopback, link-local (this also covers the `169.254.169.254` cloud
+//! metadata endpoint), private (RFC1918), unique-local (RFC4193), CGNAT
+//! (RFC6598), multicast, broadcast, "this network" (0.0.0.0/8), or
+//! unspecified range.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use once_cell::sync::Lazy;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+/// Validates `raw_url`'s scheme and resolves its host, rejecting anything
+/// that isn't a publicly-routable `http`/`https` target. Intended for
+/// eager validation (e.g. at webhook registration); does not by itself
+/// protect a later fetch from DNS rebinding — pair with [`safe_http_client`]
+/// for that.
+pub async fn validate_public_url(raw_url: &str) -> Result<url::Url, String> {
+    let url = url::Url::parse(raw_url).map_err(|e| format!("invalid URL: {e}"))?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(format!(
+                "unsupported URL scheme '{other}', only http/https are allowed"
+            ))
+        }
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?
+        .to_string();
+    let port = url.port_or_known_default().unwrap_or(80);
+
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
+        .await
+        .map_err(|e| format!("failed to resolve host '{host}': {e}"))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(format!("host '{host}' did not resolve to any address"));
+    }
+
+    for addr in &addrs {
+        if !is_globally_routable(addr.ip()) {
+            return Err(format!(
+                "'{host}' resolves to a non-public address ({}), refusing",
+                addr.ip()
+            ));
+        }
+    }
+
+    Ok(url)
+}
+
+/// A `reqwest::dns::Resolve` that rejects any resolution landing on a
+/// non-public address. Reqwest calls this for the initial request and again
+/// for every redirect hop, so wiring it into a client (see
+/// [`safe_http_client`]) closes both the "URL looked fine at registration,
+/// then someone repointed the DNS record" and "the server 302'd us to
+/// 169.254.169.254" bypasses that a one-time string check cannot.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SsrfSafeResolver;
+
+impl Resolve for SsrfSafeResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
+                .collect();
+
+            if addrs.is_empty() {
+                return Err(resolve_error(format!(
+                    "host '{host}' did not resolve to any address"
+                )));
+            }
+
+            for addr in &addrs {
+                if !is_globally_routable(addr.ip()) {
+                    return Err(resolve_error(format!(
+                        "refusing to connect: '{host}' resolves to non-public address {}",
+                        addr.ip()
+                    )));
+                }
+            }
+
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}
+
+fn resolve_error(msg: String) -> Box<dyn std::error::Error + Send + Sync> {
+    Box::new(std::io::Error::other(msg))
+}
+
+/// Shared `reqwest::Client` for fetching caller-supplied URLs (media-by-URL,
+/// webhook delivery): SSRF-safe DNS resolution on every hop plus a bounded
+/// timeout so a slow/hanging remote can't tie up a request indefinitely.
+pub fn safe_http_client() -> &'static reqwest::Client {
+    static CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
+        reqwest::Client::builder()
+            .dns_resolver(std::sync::Arc::new(SsrfSafeResolver))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build SSRF-safe HTTP client")
+    });
+    &CLIENT
+}
+
+fn is_globally_routable(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_globally_routable_v4(v4),
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(mapped) => is_globally_routable_v4(mapped),
+            None => is_globally_routable_v6(v6),
+        },
+    }
+}
+
+/// Beyond std's `Ipv4Addr::is_private`/`is_loopback`/etc: also rejects the
+/// rest of 0.0.0.0/8 ("this network", `is_unspecified` only covers the
+/// single all-zero address) and 100.64.0.0/10 (RFC 6598 carrier-grade NAT,
+/// used internally by many cloud/container networks but not covered by
+/// `is_private`).
+fn is_globally_routable_v4(ip: Ipv4Addr) -> bool {
+    if ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_multicast()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || ip.is_unspecified()
+    {
+        return false;
+    }
+    let octets = ip.octets();
+    if octets[0] == 0 {
+        return false;
+    }
+    if octets[0] == 100 && (octets[1] & 0xc0) == 64 {
+        return false;
+    }
+    true
+}
+
+/// Beyond std's `Ipv6Addr::is_loopback`/`is_unspecified`/`is_multicast`:
+/// also rejects fc00::/7 (unique local, RFC 4193) and fe80::/10
+/// (link-local) -- std doesn't expose stable checks for either yet.
+fn is_globally_routable_v6(ip: Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+        return false;
+    }
+    let seg0 = ip.segments()[0];
+    if (seg0 & 0xfe00) == 0xfc00 {
+        return false;
+    }
+    if (seg0 & 0xffc0) == 0xfe80 {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_v4_is_routable() {
+        assert!(is_globally_routable("8.8.8.8".parse().unwrap()));
+        assert!(is_globally_routable("1.1.1.1".parse().unwrap()));
+    }
+
+    /// Covers, in order: loopback, cloud metadata (link-local),
+    /// RFC1918 x3, CGNAT, unspecified, multicast, broadcast.
+    #[test]
+    fn private_and_special_v4_ranges_are_blocked() {
+        for ip in [
+            "127.0.0.1",
+            "169.254.169.254",
+            "10.0.0.5",
+            "172.16.0.1",
+            "192.168.1.1",
+            "100.64.0.1",
+            "0.0.0.0",
+            "224.0.0.1",
+            "255.255.255.255",
+        ] {
+            assert!(
+                !is_globally_routable(ip.parse().unwrap()),
+                "{ip} should not be globally routable"
+            );
+        }
+    }
+
+    #[test]
+    fn private_v6_ranges_and_mapped_v4_are_blocked() {
+        for ip in [
+            "::1",
+            "fe80::1",
+            "fc00::1",
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+        ] {
+            assert!(
+                !is_globally_routable(ip.parse().unwrap()),
+                "{ip} should not be globally routable"
+            );
+        }
+        assert!(is_globally_routable(
+            "2606:4700:4700::1111".parse().unwrap()
+        ));
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -11,9 +11,17 @@
 //! - `/api/v1/nats/*` — NATS stream ops.
 
 use axum::{
+    extract::DefaultBodyLimit,
     routing::{delete, get, post, put},
     Router,
 };
+
+/// Axum's `Bytes`-based extractors (`Multipart` fields among them) cap
+/// bodies at 2MB by default -- fine for JSON, too small for real media or a
+/// session storage archive. These routes get an explicit, deliberate raise
+/// instead of silently inheriting that default or being left unbounded.
+const MAX_MEDIA_UPLOAD_BYTES: usize = 100 * 1024 * 1024;
+const MAX_SESSION_IMPORT_BYTES: usize = 512 * 1024 * 1024;
 
 use crate::handlers;
 use crate::state::AppState;
@@ -93,11 +101,16 @@ fn session_routes() -> Router<AppState> {
         )
         .route(
             "/{session_id}/import",
-            post(handlers::sessions::import_session),
+            post(handlers::sessions::import_session)
+                .layer(DefaultBodyLimit::max(MAX_SESSION_IMPORT_BYTES)),
         )
         .route(
             "/{session_id}/device",
             get(handlers::sessions::get_device_info),
+        )
+        .route(
+            "/{session_id}/token",
+            post(handlers::sessions::issue_session_token),
         )
         .route(
             "/{session_id}/messages/text",
@@ -421,7 +434,8 @@ fn session_routes() -> Router<AppState> {
         )
         .route(
             "/{session_id}/media/upload",
-            post(handlers::media::upload_media),
+            post(handlers::media::upload_media)
+                .layer(DefaultBodyLimit::max(MAX_MEDIA_UPLOAD_BYTES)),
         )
         .route(
             "/{session_id}/media/download",

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,6 +32,13 @@ use crate::nats::NatsManager;
 /// downtime on a webhook target piled tokio tasks faster than they could
 /// drain — we observed ~600 threads on a 0 % CPU idle process. A shared
 /// client with explicit timeouts keeps each task bounded to ~10 s.
+///
+/// `dns_resolver` is [`crate::net_guard::SsrfSafeResolver`]: registration
+/// already rejects a webhook URL that resolves to a private/internal
+/// address (`net_guard::validate_public_url`), but that check happens once,
+/// up front. This resolver repeats it on every actual delivery — including
+/// redirect hops, which re-resolve their target host — so a URL that only
+/// *later* gets DNS-rebound to an internal target still can't be reached.
 fn webhook_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
@@ -40,6 +47,7 @@ fn webhook_client() -> &'static reqwest::Client {
             .connect_timeout(Duration::from_secs(5))
             .pool_idle_timeout(Duration::from_secs(90))
             .pool_max_idle_per_host(16)
+            .dns_resolver(std::sync::Arc::new(crate::net_guard::SsrfSafeResolver))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new())
     })
@@ -714,6 +722,16 @@ impl AppState {
             .and_then(|m| m.remove(webhook_id).map(|(_, v)| v))
     }
 
+    /// Delivers `payload` to every enabled, matching webhook for
+    /// `session_id`, HMAC-signing it when the webhook has a `secret`.
+    ///
+    /// The signature is computed over `{timestamp}.{payload}`, with the
+    /// timestamp also sent as `X-Webhook-Timestamp`, not over the payload
+    /// alone: a captured `(url, signature, body)` tuple would otherwise
+    /// replay forever with a still-valid signature. Binding the signature
+    /// to a timestamp that ships alongside it lets a receiver reject
+    /// anything outside a short window -- see webhooks.md for the
+    /// verification recipe receivers are expected to implement.
     pub async fn broadcast_to_webhooks(&self, session_id: &str, event: &str, payload: &str) {
         self.push_event(session_id, event, payload);
 
@@ -753,9 +771,11 @@ impl AppState {
                         tokio::time::sleep(Duration::from_millis(*delay)).await;
                     }
 
+                    let timestamp = chrono::Utc::now().timestamp();
                     let mut req = client
                         .post(&url)
                         .header("Content-Type", "application/json")
+                        .header("X-Webhook-Timestamp", timestamp.to_string())
                         .body(payload.clone());
 
                     if let Some(secret) = &secret {
@@ -764,7 +784,7 @@ impl AppState {
 
                         type HmacSha256 = Hmac<Sha256>;
                         if let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) {
-                            mac.update(payload.as_bytes());
+                            mac.update(format!("{timestamp}.{payload}").as_bytes());
                             let signature = hex::encode(mac.finalize().into_bytes());
                             req =
                                 req.header("X-Webhook-Signature", format!("sha256={}", signature));

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -3,8 +3,29 @@
 //! (`/livez`, `/readyz`, `/health`, `/metrics`) must not.
 mod common;
 
-use axum::http::StatusCode;
-use common::{call, req_get, Harness, TEST_TOKEN};
+use axum::http::{Method, StatusCode};
+use common::{call, req_get, req_json, Harness, TEST_TOKEN};
+use serde_json::json;
+use waxum::middleware::jwt::JwtAuth;
+
+/// Matches the `JWT_SECRET` the harness sets so a test can mint its own
+/// tokens with `JwtAuth::with_secret` and have them validate against the
+/// app under test.
+const TEST_JWT_SECRET: &str = "test-jwt-secret-value";
+
+async fn create_session(h: &Harness, id: &str) {
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": id}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "session {id} setup failed");
+}
 
 #[tokio::test]
 async fn api_v1_rejects_missing_token() {
@@ -34,4 +55,104 @@ async fn probes_bypass_auth() {
         let (status, _) = call(&h.app, req_get(path, None)).await;
         assert_eq!(status, StatusCode::OK, "{} should bypass auth", path);
     }
+}
+
+#[tokio::test]
+async fn issue_session_token_endpoint_returns_a_working_scoped_token() {
+    let h = Harness::new().await;
+    create_session(&h, "s-scope-a").await;
+
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-scope-a/token",
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.get("session_id").and_then(|v| v.as_str()),
+        Some("s-scope-a")
+    );
+    let token = body
+        .get("token")
+        .and_then(|v| v.as_str())
+        .expect("token field");
+
+    let (status, _) = call(&h.app, req_get("/api/v1/sessions/s-scope-a", Some(token))).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scoped_token_cannot_reach_a_different_session() {
+    let h = Harness::new().await;
+    create_session(&h, "s-scope-mine").await;
+    create_session(&h, "s-scope-other").await;
+
+    let jwt = JwtAuth::with_secret(TEST_JWT_SECRET.to_string());
+    let token = jwt
+        .generate_token("s-scope-mine", "superadmin", 1, Some("s-scope-mine"))
+        .expect("generate scoped token");
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-scope-mine", Some(&token)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "own session must stay reachable");
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-scope-other", Some(&token)),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a token scoped to one session must not reach another"
+    );
+}
+
+#[tokio::test]
+async fn scoped_token_cannot_reach_fleet_wide_endpoints() {
+    let h = Harness::new().await;
+    create_session(&h, "s-scope-fleet").await;
+
+    let jwt = JwtAuth::with_secret(TEST_JWT_SECRET.to_string());
+    let token = jwt
+        .generate_token("s-scope-fleet", "superadmin", 1, Some("s-scope-fleet"))
+        .expect("generate scoped token");
+
+    for path in ["/api/v1/sessions", "/api/v1/sessions/search"] {
+        let (status, _) = call(&h.app, req_get(path, Some(&token))).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "{path} is fleet-wide and must reject a session-scoped token"
+        );
+    }
+}
+
+#[tokio::test]
+async fn unscoped_jwt_still_reaches_every_session() {
+    let h = Harness::new().await;
+    create_session(&h, "s-scope-unrestricted").await;
+
+    let jwt = JwtAuth::with_secret(TEST_JWT_SECRET.to_string());
+    let token = jwt
+        .generate_token("boot", "superadmin", 1, None)
+        .expect("generate unscoped token");
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-scope-unrestricted", Some(&token)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _) = call(&h.app, req_get("/api/v1/sessions", Some(&token))).await;
+    assert_eq!(status, StatusCode::OK);
 }

--- a/tests/contacts_search.rs
+++ b/tests/contacts_search.rs
@@ -1,0 +1,106 @@
+//! Regression test for contacts search LIKE-escaping (security hardening
+//! pass): a search query containing literal `%`/`_` must not act as a SQL
+//! wildcard, and normal substring search must keep matching. Also guards
+//! against the MySQL-vs-SQLite `ESCAPE` clause dialect trap directly (see
+//! `db::messages::like_query`'s doc comment) by exercising the actual SQL
+//! text against a real SQLite connection rather than just checking it
+//! compiles.
+
+use tempfile::TempDir;
+
+use waxum::db::contacts::{ContactStore, ContactUpsert};
+use waxum::db::schema;
+use waxum::db::session::{DbPool, SessionManager};
+use waxum::db::sqlite_raw;
+
+/// Fresh SQLite DB in its own temp dir, with a `s1` session row seeded so
+/// contact inserts satisfy the `contacts.session_id` foreign key.
+async fn setup() -> (TempDir, DbPool) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("waxum.db");
+    let sqlite = sqlite_raw::open(db_path.to_str().unwrap()).expect("open sqlite");
+    let pool = DbPool::SQLite(sqlite);
+    schema::init_schema(&pool).await.expect("init schema");
+
+    let manager = SessionManager::new(pool.clone());
+    manager
+        .create_session("s1", None, tmp.path().to_str().unwrap())
+        .await
+        .expect("seed session");
+
+    (tmp, pool)
+}
+
+/// The query contains `%`, which -- unescaped -- would match any character
+/// sequence between "100" and "Fresh", matching both contacts below.
+/// Escaped, it must match only the one whose name literally contains "100%".
+#[tokio::test]
+async fn literal_percent_in_query_is_not_a_wildcard() {
+    let (_tmp, pool) = setup().await;
+    let store = ContactStore::new(&pool);
+
+    store
+        .upsert(&ContactUpsert {
+            session_id: "s1",
+            jid: "111@s.whatsapp.net",
+            phone: Some("111"),
+            full_name: Some("100% Fresh Produce"),
+            source: "manual",
+            ..Default::default()
+        })
+        .await
+        .expect("upsert 1");
+    store
+        .upsert(&ContactUpsert {
+            session_id: "s1",
+            jid: "222@s.whatsapp.net",
+            phone: Some("222"),
+            full_name: Some("100 Percent Fresh"),
+            source: "manual",
+            ..Default::default()
+        })
+        .await
+        .expect("upsert 2");
+
+    let results = store
+        .list("s1", Some("100% Fresh"), 20, 0)
+        .await
+        .expect("search");
+    assert_eq!(
+        results.len(),
+        1,
+        "escaped '%' must match literally, not as a wildcard: {results:?}"
+    );
+    assert_eq!(results[0].jid, "111@s.whatsapp.net");
+}
+
+#[tokio::test]
+async fn ordinary_substring_search_still_matches() {
+    let (_tmp, pool) = setup().await;
+    let store = ContactStore::new(&pool);
+
+    store
+        .upsert(&ContactUpsert {
+            session_id: "s1",
+            jid: "333@s.whatsapp.net",
+            phone: Some("333"),
+            full_name: Some("Budi Santoso"),
+            source: "manual",
+            ..Default::default()
+        })
+        .await
+        .expect("upsert");
+
+    let results = store
+        .list("s1", Some("Santoso"), 20, 0)
+        .await
+        .expect("search");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].jid, "333@s.whatsapp.net");
+
+    let no_match = store
+        .list("s1", Some("nonexistent"), 20, 0)
+        .await
+        .expect("search");
+    assert!(no_match.is_empty());
+}


### PR DESCRIPTION
## Summary

**security: OWASP Top 10 hardening pass** — full audit (4 parallel reviewers covering access control/auth, injection/crypto, SSRF/integrity/design, misconfiguration/deps/logging), then fixed everything found:

- **Critical:** hardcoded JWT fallback secret (public in this repo's history) replaced with a random per-process secret. SSRF via "send media by URL" / webhook registration+delivery / `/calls/play` audio-URL closed with a new SSRF-safe resolver (`src/net_guard.rs`) that re-validates on every DNS resolution, including redirect hops.
- **Access control:** per-session token scoping (new `POST .../sessions/{id}/token`, additive — existing tokens unaffected), constant-time token comparison, global per-IP rate limiting (`tower_governor`), configurable CORS (`CORS_ALLOWED_ORIGINS`), `Secure` console cookie over TLS.
- **Resource exhaustion:** zip-bomb caps on session import (entry count / per-file / total size), deliberate upload size limits (was relying on axum's undocumented 2MB default).
- **Webhook replay protection:** HMAC signature now covers `{timestamp}.{payload}` — **receivers verifying signatures need to update their verification code**, see `waxum-doc`'s updated Node.js/Python examples.
- Plus: security-event logging, non-root Docker user, escaped LIKE wildcards in contacts search (and a related MySQL `ESCAPE`-clause dialect bug found & fixed along the way), `cargo-audit` wired into CI (6 transitive advisories found, tracked in `audit.toml`, 0 in waxum's own direct deps).
- Full detail in the `[0.10.0]` `CHANGELOG.md` entry.

**docs: refresh CONTRIBUTING.md, add GitHub issue templates** — fixed a stale Docker image name and docs URL, added the utoipa-schema-registration step and per-session-scoping note to the "adding an endpoint" checklist, added a security-reporting pointer, and added `.github/ISSUE_TEMPLATE/` (bug report + feature request forms) since CONTRIBUTING.md referenced them but they didn't exist.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (69 tests, all passing — including new regression tests for session-token scoping, zip-bomb caps, and LIKE-escaping)
- [x] `cargo build`
- [x] `cargo audit` (new CI gate)