### PR TITLE
v0.11.0 — mintable, revocable, multi-session tokens (closes #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.11.0] - 2026-07-28
+
+### Added — mintable, revocable, multi-session tokens
+
+Closes [#44](https://github.com/imtaqin/waxum/issues/44), reopened after
+initially being closed as out-of-scope: v0.10.0's single-session token
+scoping (`POST /sessions/{id}/token`) covered isolation but not the rest
+of the original ask — attaching more than one session to a token, seeing
+what's been issued, or pulling one back before it naturally expires.
+
+- **`POST /api/v1/tokens`** — mint a token bound to one or more
+  `session_ids` (a list, not a single id), with an optional `name` label
+  and `expires_in_hours`. Requires the instance's `SUPERADMIN_TOKEN` (or
+  an unscoped superadmin JWT) to call — minting is itself a fleet-wide
+  operation, same as the token it produces cannot mint further tokens.
+- **`GET /api/v1/tokens`** — list every minted token's metadata (name,
+  bound sessions, timestamps, revoked status). Never returns the bearer
+  value itself; that's only ever shown once, in the mint response.
+- **`POST /api/v1/tokens/{id}/revoke`** — invalidate a token immediately,
+  before its natural expiry.
+- New `tokens` / `token_sessions` tables (all three backends) back this:
+  a minted token's JWT carries only an opaque `jti`; the actual session
+  bindings and revocation state are looked up server-side on every
+  request, in `jwt_auth_middleware`. That DB-backed indirection is what
+  makes immediate revocation and rebinding possible without reissuing
+  the token — a plain stateless JWT can't do either.
+- A minted token cannot log into the console (full-fleet admin UI) even
+  though its JWT `role` claim reads `superadmin` — `jti`-bearing tokens
+  are explicitly excluded from console auth.
+
+**Replaces** v0.10.0's `POST /sessions/{id}/token` (single-session,
+stateless, unrevocable) — that endpoint is removed; the `session_id` JWT
+claim it used is replaced by `jti`. Not yet in any tagged release, so
+nothing to migrate for existing deployments.
+
 ## [0.10.0] - 2026-07-28
 
 ### Security — OWASP Top 10 hardening pass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/console/handlers.rs
+++ b/src/console/handlers.rs
@@ -33,6 +33,10 @@ fn cookie_token(headers: &HeaderMap) -> Option<String> {
     None
 }
 
+/// A minted token (carries a `jti`, see `crate::db::tokens`) is a
+/// session-scoped API credential -- it must not also grant the fleet-wide
+/// console, so this rejects any JWT carrying one even if its role claim
+/// says `superadmin`.
 fn token_is_superadmin(token: &str) -> bool {
     if let Ok(superadmin) = std::env::var("SUPERADMIN_TOKEN") {
         if !superadmin.is_empty() && crate::middleware::jwt::constant_time_eq(token, &superadmin) {
@@ -41,7 +45,9 @@ fn token_is_superadmin(token: &str) -> bool {
     }
     let jwt_auth = crate::middleware::jwt::JwtAuth::new();
     match jwt_auth.validate_token(token) {
-        Ok(claims) => crate::middleware::jwt::JwtAuth::is_superadmin(&claims),
+        Ok(claims) => {
+            crate::middleware::jwt::JwtAuth::is_superadmin(&claims) && claims.jti.is_none()
+        }
         Err(_) => false,
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -28,6 +28,7 @@ pub mod scheduled;
 pub mod schema;
 pub mod session;
 pub mod sqlite_raw;
+pub mod tokens;
 pub mod webhook_dlq;
 
 pub use session::SessionManager;

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -128,7 +128,22 @@ async fn init_sqlite(pool: &crate::db::session::SqlitePool) -> anyhow::Result<()
                 UNIQUE (session_id, message_id) \
              ); \
              CREATE INDEX IF NOT EXISTS idx_messages_session_ts ON messages(session_id, msg_timestamp); \
-             CREATE INDEX IF NOT EXISTS idx_messages_chat ON messages(session_id, chat_jid);",
+             CREATE INDEX IF NOT EXISTS idx_messages_chat ON messages(session_id, chat_jid); \
+             CREATE TABLE IF NOT EXISTS tokens ( \
+                id TEXT PRIMARY KEY, \
+                name TEXT, \
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%S','now')), \
+                expires_at TEXT, \
+                revoked_at TEXT \
+             ); \
+             CREATE TABLE IF NOT EXISTS token_sessions ( \
+                token_id TEXT NOT NULL, \
+                session_id TEXT NOT NULL, \
+                PRIMARY KEY (token_id, session_id), \
+                FOREIGN KEY (token_id) REFERENCES tokens(id) ON DELETE CASCADE, \
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE \
+             ); \
+             CREATE INDEX IF NOT EXISTS idx_token_sessions_session ON token_sessions(session_id);",
         )?;
         if let Err(e) = sqlite_raw::exec_batch(
             conn,
@@ -400,6 +415,39 @@ async fn init_postgres(pool: &deadpool_postgres::Pool) -> anyhow::Result<()> {
         )
         .await?;
 
+    client
+        .execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS tokens (
+                id VARCHAR(255) PRIMARY KEY,
+                name VARCHAR(255),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                expires_at TIMESTAMPTZ,
+                revoked_at TIMESTAMPTZ
+            )
+            "#,
+            &[],
+        )
+        .await?;
+    client
+        .execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS token_sessions (
+                token_id VARCHAR(255) NOT NULL REFERENCES tokens(id) ON DELETE CASCADE,
+                session_id VARCHAR(255) NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                PRIMARY KEY (token_id, session_id)
+            )
+            "#,
+            &[],
+        )
+        .await?;
+    client
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_token_sessions_session ON token_sessions(session_id)",
+            &[],
+        )
+        .await?;
+
     Ok(())
 }
 
@@ -566,6 +614,32 @@ async fn init_mysql(pool: &mysql_async::Pool) -> anyhow::Result<()> {
             INDEX idx_messages_session_ts (session_id, msg_timestamp),
             INDEX idx_messages_chat (session_id, chat_jid),
             FULLTEXT INDEX ft_messages_body (body)
+        ) DEFAULT CHARSET=utf8mb4
+        "#,
+    )
+    .await?;
+
+    conn.query_drop(
+        r#"
+        CREATE TABLE IF NOT EXISTS tokens (
+            id VARCHAR(255) PRIMARY KEY,
+            name VARCHAR(255) NULL,
+            created_at VARCHAR(30) NOT NULL DEFAULT '1970-01-01 00:00:00',
+            expires_at VARCHAR(30) NULL,
+            revoked_at VARCHAR(30) NULL
+        ) DEFAULT CHARSET=utf8mb4
+        "#,
+    )
+    .await?;
+    conn.query_drop(
+        r#"
+        CREATE TABLE IF NOT EXISTS token_sessions (
+            token_id VARCHAR(255) NOT NULL,
+            session_id VARCHAR(255) NOT NULL,
+            PRIMARY KEY (token_id, session_id),
+            INDEX idx_token_sessions_session (session_id),
+            FOREIGN KEY (token_id) REFERENCES tokens(id) ON DELETE CASCADE,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
         ) DEFAULT CHARSET=utf8mb4
         "#,
     )

--- a/src/db/tokens.rs
+++ b/src/db/tokens.rs
@@ -1,0 +1,307 @@
+//! Persistence for session-scoped bearer tokens (`tokens` +
+//! `token_sessions`). A minted token's JWT carries only a `jti`; whether
+//! it's still valid and which sessions it may touch both live here, looked
+//! up on every authenticated request in [`crate::middleware::jwt`] --
+//! that's what makes revocation and rebinding possible without reissuing
+//! the token itself.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::db::session::{sqlite_blocking, DbPool};
+use crate::db::sqlite_raw::{self, Value as SQ};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TokenRecord {
+    pub id: String,
+    pub name: Option<String>,
+    pub session_ids: Vec<String>,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+    pub revoked_at: Option<String>,
+}
+
+/// Just enough to answer "is this token still usable, and for which
+/// sessions" -- the hot-path query run once per authenticated request for
+/// any token that carries a `jti`.
+#[derive(Debug, Clone)]
+pub struct TokenStatus {
+    pub revoked: bool,
+    pub session_ids: Vec<String>,
+}
+
+pub struct TokenStore<'a> {
+    pool: &'a DbPool,
+}
+
+impl<'a> TokenStore<'a> {
+    pub fn new(pool: &'a DbPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        id: &str,
+        name: Option<&str>,
+        expires_at: Option<DateTime<Utc>>,
+        session_ids: &[String],
+    ) -> anyhow::Result<()> {
+        match self.pool {
+            DbPool::Postgres(pg) => {
+                let client = pg.get().await?;
+                client
+                    .execute(
+                        "INSERT INTO tokens (id, name, expires_at) VALUES ($1, $2, $3)",
+                        &[&id, &name, &expires_at],
+                    )
+                    .await?;
+                for sid in session_ids {
+                    client
+                        .execute(
+                            "INSERT INTO token_sessions (token_id, session_id) VALUES ($1, $2)",
+                            &[&id, sid],
+                        )
+                        .await?;
+                }
+            }
+            DbPool::MySQL(my) => {
+                use mysql_async::prelude::*;
+                let mut conn = my.get_conn().await?;
+                let expires_str = expires_at.map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string());
+                conn.exec_drop(
+                    "INSERT INTO tokens (id, name, expires_at) VALUES (?, ?, ?)",
+                    (id, name, &expires_str),
+                )
+                .await?;
+                for sid in session_ids {
+                    conn.exec_drop(
+                        "INSERT INTO token_sessions (token_id, session_id) VALUES (?, ?)",
+                        (id, sid),
+                    )
+                    .await?;
+                }
+            }
+            DbPool::SQLite(pool) => {
+                let id = id.to_string();
+                let name = SQ::from_opt_str(name);
+                let expires_str = expires_at.map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string());
+                let session_ids = session_ids.to_vec();
+                sqlite_blocking(pool, move |conn| {
+                    sqlite_raw::execute(
+                        conn,
+                        "INSERT INTO tokens (id, name, expires_at) VALUES (?, ?, ?)",
+                        &[
+                            SQ::Text(id.clone()),
+                            name,
+                            SQ::from_opt_str(expires_str.as_deref()),
+                        ],
+                    )?;
+                    for sid in &session_ids {
+                        sqlite_raw::execute(
+                            conn,
+                            "INSERT INTO token_sessions (token_id, session_id) VALUES (?, ?)",
+                            &[SQ::Text(id.clone()), SQ::Text(sid.clone())],
+                        )?;
+                    }
+                    Ok(())
+                })
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn status(&self, id: &str) -> anyhow::Result<Option<TokenStatus>> {
+        match self.pool {
+            DbPool::Postgres(pg) => {
+                let client = pg.get().await?;
+                let row = client
+                    .query_opt("SELECT revoked_at FROM tokens WHERE id = $1", &[&id])
+                    .await?;
+                let Some(row) = row else {
+                    return Ok(None);
+                };
+                let revoked: Option<DateTime<Utc>> = row.get(0);
+                let session_rows = client
+                    .query(
+                        "SELECT session_id FROM token_sessions WHERE token_id = $1",
+                        &[&id],
+                    )
+                    .await?;
+                Ok(Some(TokenStatus {
+                    revoked: revoked.is_some(),
+                    session_ids: session_rows.iter().map(|r| r.get(0)).collect(),
+                }))
+            }
+            DbPool::MySQL(my) => {
+                use mysql_async::prelude::*;
+                let mut conn = my.get_conn().await?;
+                let revoked: Option<Option<String>> = conn
+                    .exec_first("SELECT revoked_at FROM tokens WHERE id = ?", (id,))
+                    .await?;
+                let Some(revoked_at) = revoked else {
+                    return Ok(None);
+                };
+                let session_ids: Vec<String> = conn
+                    .exec(
+                        "SELECT session_id FROM token_sessions WHERE token_id = ?",
+                        (id,),
+                    )
+                    .await?;
+                Ok(Some(TokenStatus {
+                    revoked: revoked_at.is_some(),
+                    session_ids,
+                }))
+            }
+            DbPool::SQLite(pool) => {
+                let id = id.to_string();
+                sqlite_blocking(pool, move |conn| {
+                    let revoked = sqlite_raw::query(
+                        conn,
+                        "SELECT revoked_at FROM tokens WHERE id = ?",
+                        &[SQ::Text(id.clone())],
+                        |r| r.get_string(0),
+                    )?;
+                    let Some(revoked_at) = revoked.into_iter().next() else {
+                        return Ok(None);
+                    };
+                    let session_ids = sqlite_raw::query(
+                        conn,
+                        "SELECT session_id FROM token_sessions WHERE token_id = ?",
+                        &[SQ::Text(id.clone())],
+                        |r| r.get_string(0).unwrap_or_default(),
+                    )?;
+                    Ok(Some(TokenStatus {
+                        revoked: revoked_at.is_some(),
+                        session_ids,
+                    }))
+                })
+                .await
+            }
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub async fn list(&self, limit: u32, offset: u32) -> anyhow::Result<Vec<TokenRecord>> {
+        let limit = limit.clamp(1, 1000) as i64;
+        let offset = offset as i64;
+        let mut records: Vec<TokenRecord> = match self.pool {
+            DbPool::Postgres(pg) => {
+                let client = pg.get().await?;
+                let rows = client
+                    .query(
+                        "SELECT id, name, to_char(created_at, 'YYYY-MM-DD HH24:MI:SS'), \
+                         to_char(expires_at, 'YYYY-MM-DD HH24:MI:SS'), \
+                         to_char(revoked_at, 'YYYY-MM-DD HH24:MI:SS') \
+                         FROM tokens ORDER BY created_at DESC LIMIT $1 OFFSET $2",
+                        &[&limit, &offset],
+                    )
+                    .await?;
+                rows.into_iter()
+                    .map(|r| TokenRecord {
+                        id: r.get(0),
+                        name: r.get(1),
+                        session_ids: Vec::new(),
+                        created_at: r.get(2),
+                        expires_at: r.get(3),
+                        revoked_at: r.get(4),
+                    })
+                    .collect()
+            }
+            DbPool::MySQL(my) => {
+                use mysql_async::prelude::*;
+                let mut conn = my.get_conn().await?;
+                let rows: Vec<(
+                    String,
+                    Option<String>,
+                    String,
+                    Option<String>,
+                    Option<String>,
+                )> = conn
+                    .exec(
+                        "SELECT id, name, created_at, expires_at, revoked_at \
+                         FROM tokens ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                        (limit, offset),
+                    )
+                    .await?;
+                rows.into_iter()
+                    .map(|r| TokenRecord {
+                        id: r.0,
+                        name: r.1,
+                        session_ids: Vec::new(),
+                        created_at: r.2,
+                        expires_at: r.3,
+                        revoked_at: r.4,
+                    })
+                    .collect()
+            }
+            DbPool::SQLite(pool) => {
+                sqlite_blocking(pool, move |conn| {
+                    sqlite_raw::query(
+                        conn,
+                        "SELECT id, name, created_at, expires_at, revoked_at \
+                         FROM tokens ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                        &[SQ::Int(limit), SQ::Int(offset)],
+                        |r| TokenRecord {
+                            id: r.get_string(0).unwrap_or_default(),
+                            name: r.get_string(1),
+                            session_ids: Vec::new(),
+                            created_at: r.get_string(2).unwrap_or_default(),
+                            expires_at: r.get_string(3),
+                            revoked_at: r.get_string(4),
+                        },
+                    )
+                })
+                .await?
+            }
+        };
+
+        for record in &mut records {
+            if let Some(status) = self.status(&record.id).await? {
+                record.session_ids = status.session_ids;
+            }
+        }
+        Ok(records)
+    }
+
+    /// Returns `true` if a not-already-revoked token with this id was found
+    /// and revoked; `false` if it didn't exist or was already revoked.
+    pub async fn revoke(&self, id: &str) -> anyhow::Result<bool> {
+        match self.pool {
+            DbPool::Postgres(pg) => {
+                let client = pg.get().await?;
+                let n = client
+                    .execute(
+                        "UPDATE tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL",
+                        &[&id],
+                    )
+                    .await?;
+                Ok(n > 0)
+            }
+            DbPool::MySQL(my) => {
+                use mysql_async::prelude::*;
+                let mut conn = my.get_conn().await?;
+                let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+                conn.exec_drop(
+                    "UPDATE tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL",
+                    (&now, id),
+                )
+                .await?;
+                Ok(conn.affected_rows() > 0)
+            }
+            DbPool::SQLite(pool) => {
+                let id = id.to_string();
+                sqlite_blocking(pool, move |conn| {
+                    let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+                    let changed = sqlite_raw::execute(
+                        conn,
+                        "UPDATE tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL",
+                        &[SQ::Text(now), SQ::Text(id)],
+                    )?;
+                    Ok(changed > 0)
+                })
+                .await
+            }
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,9 @@ pub enum ApiError {
     #[error("Webhook not found: {0}")]
     WebhookNotFound(String),
 
+    #[error("Token not found or already revoked: {0}")]
+    TokenNotFound(String),
+
     #[error("Rate limited")]
     RateLimited,
 
@@ -102,6 +105,7 @@ impl IntoResponse for ApiError {
             }
             ApiError::WebhookAlreadyExists(_) => (StatusCode::CONFLICT, self.to_string()),
             ApiError::WebhookNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
+            ApiError::TokenNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ApiError::RateLimited => (StatusCode::TOO_MANY_REQUESTS, self.to_string()),
             ApiError::TemporaryBan(_) => (StatusCode::TOO_MANY_REQUESTS, self.to_string()),
             ApiError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -47,4 +47,5 @@ pub mod search;
 pub mod sessions;
 pub mod status;
 pub mod tags;
+pub mod tokens;
 pub mod webhooks;

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -9,9 +9,9 @@ use crate::device_props::ResolvedDeviceProps;
 use crate::error::ApiError;
 use crate::models::common::SuccessResponse;
 use crate::models::sessions::{
-    ConnectRequest, CreateSessionRequest, CreateSessionResponse, DeviceInfo,
-    IssueSessionTokenRequest, IssueSessionTokenResponse, PairCodeRequest, PairCodeResponse,
-    QrCodeResponse, SessionInfo, SessionListResponse, SessionStatus, SessionStatusResponse,
+    ConnectRequest, CreateSessionRequest, CreateSessionResponse, DeviceInfo, PairCodeRequest,
+    PairCodeResponse, QrCodeResponse, SessionInfo, SessionListResponse, SessionStatus,
+    SessionStatusResponse,
 };
 use crate::models::webhooks::{WebhookConfig, WebhookEvent};
 use crate::state::AppState;
@@ -891,52 +891,6 @@ pub async fn get_device_info(
         phone_number: pn,
         lid,
         push_name,
-    }))
-}
-
-#[utoipa::path(
-    post,
-    security(("bearer_auth" = [])),
-    path = "/api/v1/sessions/{session_id}/token",
-    tag = "sessions",
-    params(
-        ("session_id" = String, Path, description = "Session ID")
-    ),
-    request_body = IssueSessionTokenRequest,
-    responses(
-        (status = 200, description = "Session-scoped token issued", body = IssueSessionTokenResponse),
-        (status = 404, description = "Session not found")
-    )
-)]
-pub async fn issue_session_token(
-    State(state): State<AppState>,
-    Path(session_id): Path<String>,
-    Json(request): Json<IssueSessionTokenRequest>,
-) -> Result<Json<IssueSessionTokenResponse>, ApiError> {
-    let _ = state
-        .session_manager()
-        .get_session(&session_id)
-        .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?
-        .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
-
-    let expires_in_hours = request.expires_in_hours.unwrap_or(24 * 30).max(1);
-
-    let jwt_auth = crate::middleware::jwt::JwtAuth::new();
-    let token = jwt_auth
-        .generate_token(
-            &session_id,
-            "superadmin",
-            expires_in_hours,
-            Some(&session_id),
-        )
-        .map_err(|e| ApiError::Internal(format!("failed to generate token: {e}")))?;
-    let expires_at = (chrono::Utc::now() + chrono::Duration::hours(expires_in_hours)).timestamp();
-
-    Ok(Json(IssueSessionTokenResponse {
-        token,
-        session_id,
-        expires_at,
     }))
 }
 

--- a/src/handlers/tokens.rs
+++ b/src/handlers/tokens.rs
@@ -1,0 +1,131 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use uuid::Uuid;
+
+use crate::error::ApiError;
+use crate::models::common::SuccessResponse;
+use crate::models::tokens::{MintTokenRequest, MintTokenResponse, TokenListResponse, TokenSummary};
+use crate::state::AppState;
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/tokens",
+    tag = "tokens",
+    request_body = MintTokenRequest,
+    responses(
+        (status = 200, description = "Token minted", body = MintTokenResponse),
+        (status = 400, description = "Invalid request (empty session_ids)"),
+        (status = 404, description = "One of the requested sessions doesn't exist")
+    )
+)]
+pub async fn mint_token(
+    State(state): State<AppState>,
+    Json(request): Json<MintTokenRequest>,
+) -> Result<Json<MintTokenResponse>, ApiError> {
+    if request.session_ids.is_empty() {
+        return Err(ApiError::BadRequest(
+            "session_ids must not be empty".to_string(),
+        ));
+    }
+
+    for session_id in &request.session_ids {
+        state
+            .session_manager()
+            .get_session(session_id)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?
+            .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
+    }
+
+    let id = Uuid::new_v4().to_string();
+    let expires_in_hours = request.expires_in_hours.unwrap_or(24 * 30).max(1);
+    let expires_at = chrono::Utc::now() + chrono::Duration::hours(expires_in_hours);
+
+    let store = crate::db::tokens::TokenStore::new(state.session_manager().pool());
+    store
+        .create(
+            &id,
+            request.name.as_deref(),
+            Some(expires_at),
+            &request.session_ids,
+        )
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    let jwt_auth = crate::middleware::jwt::JwtAuth::new();
+    let token = jwt_auth
+        .generate_token(&id, "superadmin", expires_in_hours, Some(&id))
+        .map_err(|e| ApiError::Internal(format!("failed to generate token: {e}")))?;
+
+    Ok(Json(MintTokenResponse {
+        id,
+        token,
+        name: request.name,
+        session_ids: request.session_ids,
+        expires_at: expires_at.timestamp(),
+    }))
+}
+
+#[utoipa::path(
+    get,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/tokens",
+    tag = "tokens",
+    responses(
+        (status = 200, description = "List of minted tokens (metadata only, never the bearer value)", body = TokenListResponse)
+    )
+)]
+pub async fn list_tokens(
+    State(state): State<AppState>,
+) -> Result<Json<TokenListResponse>, ApiError> {
+    let store = crate::db::tokens::TokenStore::new(state.session_manager().pool());
+    let records = store
+        .list(1000, 0)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let count = records.len();
+    let tokens = records
+        .into_iter()
+        .map(|r| TokenSummary {
+            id: r.id,
+            name: r.name,
+            session_ids: r.session_ids,
+            created_at: r.created_at,
+            expires_at: r.expires_at,
+            revoked: r.revoked_at.is_some(),
+        })
+        .collect();
+    Ok(Json(TokenListResponse { tokens, count }))
+}
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/tokens/{id}/revoke",
+    tag = "tokens",
+    params(
+        ("id" = String, Path, description = "Token id, as returned by POST /tokens")
+    ),
+    responses(
+        (status = 200, description = "Token revoked", body = SuccessResponse),
+        (status = 404, description = "Token not found or already revoked")
+    )
+)]
+pub async fn revoke_token(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<SuccessResponse>, ApiError> {
+    let store = crate::db::tokens::TokenStore::new(state.session_manager().pool());
+    let revoked = store
+        .revoke(&id)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    if revoked {
+        Ok(Json(SuccessResponse::with_message("Token revoked")))
+    } else {
+        Err(ApiError::TokenNotFound(id))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,6 @@ use state::AppState;
         handlers::sessions::export_session,
         handlers::sessions::import_session,
         handlers::sessions::get_device_info,
-        handlers::sessions::issue_session_token,
 
         handlers::messages::send_text,
         handlers::messages::send_image,
@@ -236,6 +235,10 @@ use state::AppState;
 
         handlers::search::search_session_messages,
         handlers::search::search_all_messages,
+
+        handlers::tokens::mint_token,
+        handlers::tokens::list_tokens,
+        handlers::tokens::revoke_token,
     ),
     components(
         schemas(
@@ -252,8 +255,6 @@ use state::AppState;
             models::sessions::QrCodeResponse,
             models::sessions::SessionStatusResponse,
             models::sessions::DeviceInfo,
-            models::sessions::IssueSessionTokenRequest,
-            models::sessions::IssueSessionTokenResponse,
 
             models::messages::SendTextRequest,
             models::messages::SendImageRequest,
@@ -386,6 +387,11 @@ use state::AppState;
             models::webhooks::WebhookListResponse,
             models::webhooks::WebhookRequest,
 
+            models::tokens::MintTokenRequest,
+            models::tokens::MintTokenResponse,
+            models::tokens::TokenSummary,
+            models::tokens::TokenListResponse,
+
             models::schedule::ScheduledMessage,
             models::schedule::ScheduledStatus,
             models::schedule::ScheduledListResponse,
@@ -429,7 +435,8 @@ use state::AppState;
         (name = "operations", description = "Spam reporting, TCToken, reconnection, and sync operations"),
         (name = "scheduler", description = "Scheduled (deferred) message sending"),
         (name = "blast", description = "Bulk-send (blast) jobs with pacing, retry and DLQ"),
-        (name = "nats", description = "NATS JetStream management and status")
+        (name = "nats", description = "NATS JetStream management and status"),
+        (name = "tokens", description = "Mint, list, and revoke session-scoped bearer tokens")
     )
 )]
 struct ApiDoc;
@@ -853,7 +860,8 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
     let app = create_router()
         .merge(swagger_router)
         .merge(console::console_router())
-        .layer(axum::middleware::from_fn(
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
             middleware::jwt::jwt_auth_middleware,
         ))
         .layer(TraceLayer::new_for_http())

--- a/src/middleware/jwt.rs
+++ b/src/middleware/jwt.rs
@@ -6,6 +6,13 @@
 //! - the plain-string `SUPERADMIN_TOKEN` (env), or
 //! - a JWT signed with `JWT_SECRET` whose `role` claim is `superadmin`.
 //!
+//! A token minted via `POST /api/v1/tokens` carries a `jti`; that gets
+//! looked up in the `tokens`/`token_sessions` tables (see
+//! [`crate::db::tokens`]) on every request to enforce revocation and
+//! session scope. Tokens without a `jti` -- `SUPERADMIN_TOKEN` and the
+//! unscoped JWT printed at boot -- skip that lookup entirely and reach
+//! every session, unchanged from before this existed.
+//!
 //! `/health` and `/metrics` are always allowed through so probes and
 //! scrapers don't need credentials. `/swagger-ui` and `/api-docs` go
 //! through the same check as everything else — either header carries the
@@ -15,7 +22,7 @@
 
 use axum::{
     body::Body,
-    extract::Request,
+    extract::{Request, State},
     http::{header, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
@@ -26,6 +33,8 @@ use once_cell::sync::Lazy;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+
+use crate::state::AppState;
 
 /// Process-local fallback signing secret, used only when `JWT_SECRET` is
 /// unset. Generated once per process from OS entropy rather than a fixed
@@ -54,15 +63,15 @@ pub struct Claims {
 
     pub iat: usize,
 
-    /// Restricts this token to a single `session_id`, checked in
-    /// [`jwt_auth_middleware`] against every `/api/v1/sessions/{session_id}/*`
-    /// request. `None` (the default for tokens minted before this field
+    /// Identifies this token's row in the `tokens` table (see
+    /// [`crate::db::tokens`]), checked on every request in
+    /// [`jwt_auth_middleware`] for revocation and session-scope
+    /// enforcement. `None` (the default for tokens issued before this field
     /// existed, and for the operator-wide `SUPERADMIN_TOKEN`/boot token) is
-    /// unrestricted -- unchanged, pre-existing behavior. `Some(id)` is how a
-    /// customer-facing token is handed out without also granting it every
-    /// *other* customer's session on the same instance.
+    /// unrestricted and skips the DB lookup entirely -- unchanged,
+    /// pre-existing behavior.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
+    pub jti: Option<String>,
 }
 
 #[derive(Clone)]
@@ -92,7 +101,7 @@ impl JwtAuth {
         subject: &str,
         role: &str,
         expires_in_hours: i64,
-        session_id: Option<&str>,
+        jti: Option<&str>,
     ) -> Result<String, jsonwebtoken::errors::Error> {
         let now = chrono::Utc::now();
         let exp = (now + chrono::Duration::hours(expires_in_hours)).timestamp() as usize;
@@ -103,7 +112,7 @@ impl JwtAuth {
             role: role.to_string(),
             exp,
             iat,
-            session_id: session_id.map(|s| s.to_string()),
+            jti: jti.map(|s| s.to_string()),
         };
 
         encode(
@@ -139,7 +148,11 @@ fn peer_ip(request: &Request<Body>) -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response {
+pub async fn jwt_auth_middleware(
+    State(state): State<AppState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
     let path = request.uri().path();
     if matches!(path, "/health" | "/livez" | "/readyz" | "/metrics") {
         return next.run(request).await;
@@ -199,15 +212,31 @@ pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response
                 return forbidden_response("Superadmin role required");
             }
 
-            if let Some(scope) = claims.session_id.as_deref() {
+            if let Some(jti) = claims.jti.as_deref() {
+                let store = crate::db::tokens::TokenStore::new(state.session_manager().pool());
+                let status = match store.status(jti).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::error!(peer = %peer, path = %path, error = %e, "auth: token status lookup failed");
+                        return unauthorized_response("Token status lookup failed");
+                    }
+                };
+                let Some(status) = status else {
+                    tracing::warn!(peer = %peer, path = %path, jti = %jti, "auth: token has no matching record (revoked/deleted?)");
+                    return forbidden_response("Token is no longer valid");
+                };
+                if status.revoked {
+                    tracing::warn!(peer = %peer, path = %path, jti = %jti, "auth: revoked token used");
+                    return forbidden_response("Token has been revoked");
+                }
                 match session_id_from_path(path) {
-                    Some(requested) if requested == scope => {}
+                    Some(requested) if status.session_ids.iter().any(|s| s == requested) => {}
                     _ => {
                         tracing::warn!(
-                            peer = %peer, path = %path, scope = %scope,
-                            "auth: token scoped to a different session attempted cross-session access"
+                            peer = %peer, path = %path, jti = %jti,
+                            "auth: token attempted access outside its bound sessions"
                         );
-                        return forbidden_response("Token is scoped to a different session");
+                        return forbidden_response("Token is not authorized for this session");
                     }
                 }
             }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,4 +15,5 @@ pub mod schedule;
 pub mod search;
 pub mod sessions;
 pub mod status;
+pub mod tokens;
 pub mod webhooks;

--- a/src/models/sessions.rs
+++ b/src/models/sessions.rs
@@ -210,29 +210,6 @@ pub struct SessionStatusResponse {
     pub pair: PairStatus,
 }
 
-/// Request body for minting a session-scoped bearer token.
-#[derive(Debug, Deserialize, ToSchema)]
-pub struct IssueSessionTokenRequest {
-    /// How long the token stays valid. Defaults to 720 (30 days) when omitted.
-    #[schema(example = 720)]
-    pub expires_in_hours: Option<i64>,
-}
-
-/// A bearer token restricted to a single session -- unlike the instance's
-/// `SUPERADMIN_TOKEN` or an unscoped superadmin JWT, this token is rejected
-/// by [`crate::middleware::jwt::jwt_auth_middleware`] for every other
-/// session_id and for fleet-wide endpoints (list/purge/disconnect-all/etc).
-/// Meant for handing a single customer access to only their own WhatsApp
-/// session on a shared instance.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct IssueSessionTokenResponse {
-    /// Bearer token, valid only for this session_id.
-    pub token: String,
-    pub session_id: String,
-    /// Unix timestamp the token stops validating.
-    pub expires_at: i64,
-}
-
 /// Device information
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct DeviceInfo {

--- a/src/models/tokens.rs
+++ b/src/models/tokens.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Request to mint a session-scoped bearer token.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MintTokenRequest {
+    /// Human-readable label for this token (shown in `GET /tokens`, not
+    /// used for anything security-relevant).
+    #[schema(example = "customer-mobile-app")]
+    pub name: Option<String>,
+    /// Session IDs this token may access. Must be non-empty -- a token
+    /// scoped to zero sessions can't reach any `/sessions/{id}/*` route and
+    /// is never a useful credential to mint.
+    #[schema(example = json!(["my-session"]))]
+    pub session_ids: Vec<String>,
+    /// How long the token stays valid. Defaults to 720 (30 days) when omitted.
+    #[schema(example = 720)]
+    pub expires_in_hours: Option<i64>,
+}
+
+/// A freshly minted token -- the only time the raw bearer value is ever
+/// returned. `GET /tokens` only shows metadata, never the token itself.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MintTokenResponse {
+    /// Token id (the JWT's `jti`), used to revoke it later via
+    /// `POST /tokens/{id}/revoke`.
+    pub id: String,
+    /// Bearer token. Store it now -- it can't be retrieved again.
+    pub token: String,
+    pub name: Option<String>,
+    pub session_ids: Vec<String>,
+    /// Unix timestamp the token stops validating.
+    pub expires_at: i64,
+}
+
+/// Metadata for a minted token -- never includes the bearer value itself.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TokenSummary {
+    pub id: String,
+    pub name: Option<String>,
+    pub session_ids: Vec<String>,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+    pub revoked: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TokenListResponse {
+    pub tokens: Vec<TokenSummary>,
+    pub count: usize,
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -54,6 +54,11 @@ fn api_routes() -> Router<AppState> {
             "/messages/search",
             get(handlers::search::search_all_messages),
         )
+        .route(
+            "/tokens",
+            post(handlers::tokens::mint_token).get(handlers::tokens::list_tokens),
+        )
+        .route("/tokens/{id}/revoke", post(handlers::tokens::revoke_token))
         .nest("/sessions", session_routes())
         .nest("/nats", nats_routes())
 }
@@ -107,10 +112,6 @@ fn session_routes() -> Router<AppState> {
         .route(
             "/{session_id}/device",
             get(handlers::sessions::get_device_info),
-        )
-        .route(
-            "/{session_id}/token",
-            post(handlers::sessions::issue_session_token),
         )
         .route(
             "/{session_id}/messages/text",

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -57,33 +57,73 @@ async fn probes_bypass_auth() {
     }
 }
 
-#[tokio::test]
-async fn issue_session_token_endpoint_returns_a_working_scoped_token() {
-    let h = Harness::new().await;
-    create_session(&h, "s-scope-a").await;
-
+/// Mints a token via `POST /api/v1/tokens` and returns `(id, token)`.
+async fn mint_token(h: &Harness, session_ids: &[&str], name: Option<&str>) -> (String, String) {
     let (status, body) = call(
         &h.app,
         req_json(
             Method::POST,
-            "/api/v1/sessions/s-scope-a/token",
+            "/api/v1/tokens",
             Some(TEST_TOKEN),
-            json!({}),
+            json!({"session_ids": session_ids, "name": name}),
         ),
     )
     .await;
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(
-        body.get("session_id").and_then(|v| v.as_str()),
-        Some("s-scope-a")
-    );
+    assert_eq!(status, StatusCode::OK, "mint failed: {body:?}");
+    let id = body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .expect("id field")
+        .to_string();
     let token = body
         .get("token")
         .and_then(|v| v.as_str())
-        .expect("token field");
+        .expect("token field")
+        .to_string();
+    (id, token)
+}
 
-    let (status, _) = call(&h.app, req_get("/api/v1/sessions/s-scope-a", Some(token))).await;
+#[tokio::test]
+async fn mint_token_endpoint_returns_a_working_scoped_token() {
+    let h = Harness::new().await;
+    create_session(&h, "s-scope-a").await;
+
+    let (_, token) = mint_token(&h, &["s-scope-a"], Some("mobile-app")).await;
+
+    let (status, _) = call(&h.app, req_get("/api/v1/sessions/s-scope-a", Some(&token))).await;
     assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn mint_token_rejects_empty_session_ids() {
+    let h = Harness::new().await;
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/tokens",
+            Some(TEST_TOKEN),
+            json!({"session_ids": []}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn mint_token_rejects_unknown_session() {
+    let h = Harness::new().await;
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/tokens",
+            Some(TEST_TOKEN),
+            json!({"session_ids": ["does-not-exist"]}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -92,10 +132,7 @@ async fn scoped_token_cannot_reach_a_different_session() {
     create_session(&h, "s-scope-mine").await;
     create_session(&h, "s-scope-other").await;
 
-    let jwt = JwtAuth::with_secret(TEST_JWT_SECRET.to_string());
-    let token = jwt
-        .generate_token("s-scope-mine", "superadmin", 1, Some("s-scope-mine"))
-        .expect("generate scoped token");
+    let (_, token) = mint_token(&h, &["s-scope-mine"], None).await;
 
     let (status, _) = call(
         &h.app,
@@ -117,16 +154,38 @@ async fn scoped_token_cannot_reach_a_different_session() {
 }
 
 #[tokio::test]
+async fn token_can_be_scoped_to_multiple_sessions() {
+    let h = Harness::new().await;
+    create_session(&h, "s-multi-a").await;
+    create_session(&h, "s-multi-b").await;
+    create_session(&h, "s-multi-c").await;
+
+    let (_, token) = mint_token(&h, &["s-multi-a", "s-multi-b"], None).await;
+
+    for id in ["s-multi-a", "s-multi-b"] {
+        let (status, _) = call(
+            &h.app,
+            req_get(&format!("/api/v1/sessions/{id}"), Some(&token)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{id} should be reachable");
+    }
+    let (status, _) = call(&h.app, req_get("/api/v1/sessions/s-multi-c", Some(&token))).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "unbound session must reject");
+}
+
+#[tokio::test]
 async fn scoped_token_cannot_reach_fleet_wide_endpoints() {
     let h = Harness::new().await;
     create_session(&h, "s-scope-fleet").await;
 
-    let jwt = JwtAuth::with_secret(TEST_JWT_SECRET.to_string());
-    let token = jwt
-        .generate_token("s-scope-fleet", "superadmin", 1, Some("s-scope-fleet"))
-        .expect("generate scoped token");
+    let (_, token) = mint_token(&h, &["s-scope-fleet"], None).await;
 
-    for path in ["/api/v1/sessions", "/api/v1/sessions/search"] {
+    for path in [
+        "/api/v1/sessions",
+        "/api/v1/sessions/search",
+        "/api/v1/tokens",
+    ] {
         let (status, _) = call(&h.app, req_get(path, Some(&token))).await;
         assert_eq!(
             status,
@@ -134,6 +193,86 @@ async fn scoped_token_cannot_reach_fleet_wide_endpoints() {
             "{path} is fleet-wide and must reject a session-scoped token"
         );
     }
+}
+
+#[tokio::test]
+async fn revoked_token_is_rejected() {
+    let h = Harness::new().await;
+    create_session(&h, "s-revoke").await;
+
+    let (id, token) = mint_token(&h, &["s-revoke"], None).await;
+
+    let (status, _) = call(&h.app, req_get("/api/v1/sessions/s-revoke", Some(&token))).await;
+    assert_eq!(status, StatusCode::OK, "must work before revocation");
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            &format!("/api/v1/tokens/{id}/revoke"),
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _) = call(&h.app, req_get("/api/v1/sessions/s-revoke", Some(&token))).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a revoked token must stop working immediately, before its natural expiry"
+    );
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            &format!("/api/v1/tokens/{id}/revoke"),
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "revoking an already-revoked token is a 404, not a silent no-op"
+    );
+}
+
+#[tokio::test]
+async fn list_tokens_shows_metadata_but_never_the_bearer_value() {
+    let h = Harness::new().await;
+    create_session(&h, "s-list").await;
+
+    let (id, token) = mint_token(&h, &["s-list"], Some("audit-label")).await;
+
+    let (status, body) = call(&h.app, req_get("/api/v1/tokens", Some(TEST_TOKEN))).await;
+    assert_eq!(status, StatusCode::OK);
+    let raw = body.to_string();
+    assert!(
+        !raw.contains(&token),
+        "token list response must never include the raw bearer value"
+    );
+
+    let entries = body.get("tokens").and_then(|v| v.as_array()).unwrap();
+    let entry = entries
+        .iter()
+        .find(|e| e.get("id").and_then(|v| v.as_str()) == Some(id.as_str()))
+        .expect("minted token should be listed");
+    assert_eq!(
+        entry.get("name").and_then(|v| v.as_str()),
+        Some("audit-label")
+    );
+    assert_eq!(entry.get("revoked").and_then(|v| v.as_bool()), Some(false));
+    assert_eq!(
+        entry
+            .get("session_ids")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len()),
+        Some(1)
+    );
 }
 
 #[tokio::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -48,7 +48,8 @@ impl Harness {
         let recordings = waxum::storage::RecordingStore::local(tmp.path().to_str().unwrap());
         let state = AppState::new(pool.clone(), None, recordings).await;
         let app: Router = create_router()
-            .layer(axum::middleware::from_fn(
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
                 middleware::jwt::jwt_auth_middleware,
             ))
             .with_state(state);


### PR DESCRIPTION
## Summary

Closes #44 ("Generating more tokens"), reopened after initially being closed as out-of-scope. v0.10.0 (already merged, PR #56) added single-session token scoping; this closes the rest of the original ask.

- **`POST /api/v1/tokens`** — mint a token bound to a *list* of `session_ids` (not just one), with an optional `name` label and `expires_in_hours`. Fleet-wide operation — requires `SUPERADMIN_TOKEN` or an unscoped superadmin JWT.
- **`GET /api/v1/tokens`** — list every minted token's metadata (name, bound sessions, timestamps, revoked status). Never returns the bearer value — that's shown once, at mint time only.
- **`POST /api/v1/tokens/{id}/revoke`** — invalidate a token immediately, before its natural expiry.
- New `tokens` / `token_sessions` tables (all three DB backends). The JWT now carries only an opaque `jti`; `jwt_auth_middleware` looks up revocation status and session bindings from the DB on every request — that DB-backed indirection is what makes immediate revocation and rebinding possible without reissuing the token.
- A minted token cannot log into the console (full-fleet admin UI) even though its JWT `role` claim reads `superadmin` — `jti`-bearing tokens are explicitly excluded from console auth.
- **Replaces** v0.10.0's `POST /sessions/{id}/token` (single-session, stateless, unrevocable) — removed; never shipped in a tagged release, nothing to migrate.
- Docs: new `waxum-doc/docs/api/tokens.md`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (76 tests, all passing — 9 new/rewritten covering mint, cross-session rejection, fleet-wide rejection, multi-session binding, revocation, list-never-leaks-token)
- [x] `cargo build`