### PR TITLE
v0.11.1 — fix auto-reconnect: honest socket re-establish, self-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.11.1] - 2026-07-28
+
+### Fixed — auto-reconnect actually re-establishes the socket, honest status, self-heal
+
+Auto-reconnect was enabled but could get stuck instead of re-establishing
+the socket after a drop. Root causes, all fixed:
+
+- **`connect_session` raced a zombie client.** It cleared its own `Arc<Client>`
+  slot before rebuilding but never called `client.disconnect()` on
+  whatever was still there — the old client's background task (and its
+  own internal reconnect loop) kept running against the *same on-disk
+  device store*, so a manual reconnect could spawn a second `Client`
+  fighting the first for the same socket. Now disconnects the old client
+  cleanly first, every time.
+- **`connect_session` refused to act (409) while status was `Connecting`**
+  — which is exactly the status a session sits in for the *entire*
+  duration of whatsapp-rust's internal backoff after a drop. There was no
+  way to force a clean rebuild during the one window an operator would
+  need to. `Connecting` no longer blocks a reconnect request (`WaitingForQr`
+  / `WaitingForPairCode` still do, so an in-progress pairing flow isn't
+  clobbered).
+- **Status honesty**: `Event::Disconnected` never persisted to the DB
+  (every sibling transition did) and `GET /sessions/{id}` (singular)
+  used the raw cached status with no reconciliation against the live
+  socket, unlike `GET /sessions` (list) and `GET /sessions/{id}/status` —
+  so the same session could report `logged_in` from one endpoint and
+  `connecting` from another at the same instant. Both fixed: the socket
+  dying now reliably degrades `is_logged_in` and every read endpoint
+  agrees.
+- **Self-heal**: whatsapp-rust's own reconnect loop has no attempt cap of
+  its own — it backs off up to 15 minutes between tries and keeps going
+  forever, which reads as "stuck" during a prolonged outage or a wedged
+  handshake. A new watchdog (`RECONNECT_WATCHDOG_POLL_MS`, default 30s)
+  now forces the same full rebuild a manual reconnect performs once a
+  session has been retrying past `RECONNECT_MAX_ATTEMPTS` (default 10,
+  read from `client.stats().reconnect_errors`) or `RECONNECT_MAX_STUCK_SECS`
+  (default 600s) — cleanly disconnecting the wedged client and respawning
+  fresh, plus broadcasting a synthetic `disconnected` webhook/event as a
+  safety net for the (upstream) case where a socket dies silently without
+  whatsapp-rust ever dispatching a disconnect event at all.
+
 ## [0.11.0] - 2026-07-28
 
 ### Added — mintable, revocable, multi-session tokens

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use axum::{
     extract::{Multipart, Path, State},
     response::Response as AxumResponse,
@@ -177,7 +179,7 @@ pub async fn get_session(
         .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
 
     if let Some(runtime) = state.get_session(&session_id) {
-        session.status = runtime.get_status();
+        session.status = runtime.effective_status();
         session.is_logged_in = session.status == SessionStatus::LoggedIn;
     }
 
@@ -332,6 +334,16 @@ pub async fn get_qr_code(
     }))
 }
 
+/// Forces a clean rebuild when the session isn't actually live: cleanly
+/// disconnects whatever client is cached (if any) before rebuilding, rather
+/// than only clearing the `Arc` slot and leaving an old `Client`'s
+/// background task and socket running -- two live clients racing for the
+/// same on-disk device store is a real failure mode, not a hypothetical
+/// one. `Connecting` is deliberately *not* one of the refused statuses
+/// below: it's exactly the state a session sits in for the whole duration
+/// of whatsapp-rust's internal reconnect backoff after a drop, and an
+/// operator needs a way to force a rebuild out of it instead of waiting
+/// out however many backoff cycles remain.
 #[utoipa::path(
     post,
     path = "/api/v1/sessions/{session_id}/connect",
@@ -373,14 +385,16 @@ pub async fn connect_session(
         let s = runtime.get_status();
         if matches!(
             s,
-            SessionStatus::Connecting
-                | SessionStatus::WaitingForQr
-                | SessionStatus::WaitingForPairCode
+            SessionStatus::WaitingForQr | SessionStatus::WaitingForPairCode
         ) {
             return Err(ApiError::AlreadyConnected);
         }
+        if let Some(old_client) = runtime.get_client() {
+            old_client.disconnect().await;
+        }
         runtime.set_client(None);
         runtime.set_status(SessionStatus::Disconnected);
+        runtime.clear_reconnecting();
     }
 
     let storage_path = state
@@ -590,6 +604,7 @@ pub async fn disconnect_session(
     client.disconnect().await;
     runtime.set_status(SessionStatus::Disconnected);
     runtime.set_client(None);
+    runtime.clear_reconnecting();
 
     let _ = state
         .session_manager()
@@ -635,6 +650,7 @@ pub async fn export_session(
         }
         runtime.set_status(SessionStatus::Disconnected);
         runtime.set_client(None);
+        runtime.clear_reconnecting();
     }
     let _ = state
         .session_manager()
@@ -971,6 +987,113 @@ pub async fn reconnect_all_on_startup(state: AppState) {
     }
 }
 
+/// Self-heal for a session wedged in whatsapp-rust's own reconnect backoff.
+///
+/// whatsapp-rust's internal retry loop (inside `bot.run()`) has no attempt
+/// cap of its own -- it backs off up to 15 minutes between tries and keeps
+/// going forever, which in practice reads as "auto-reconnect enabled but
+/// stuck" during a prolonged outage or a wedged handshake. This watchdog
+/// ticks every `RECONNECT_WATCHDOG_POLL_MS` (default 30s) and, for any
+/// session that has been in `Connecting` for longer than
+/// `RECONNECT_MAX_STUCK_SECS` (default 600s) *or* whose
+/// `client.stats().reconnect_errors` has crossed `RECONNECT_MAX_ATTEMPTS`
+/// (default 10), forces the same full rebuild a manual `POST .../connect`
+/// performs: cleanly disconnect the wedged client (stopping its internal
+/// loop) and spawn [`connect_client`] fresh, rather than trusting the
+/// crate to eventually recover on its own. Also broadcasts a synthetic
+/// `disconnected` webhook/event as a safety net -- see the module docs on
+/// `Event::Disconnected` for why the crate doesn't always dispatch one for
+/// a socket that dies silently.
+pub async fn run_reconnect_watchdog(state: AppState) {
+    let poll_ms: u64 = std::env::var("RECONNECT_WATCHDOG_POLL_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(30_000);
+    let max_attempts: u32 = std::env::var("RECONNECT_MAX_ATTEMPTS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+    let max_stuck_secs: i64 = std::env::var("RECONNECT_MAX_STUCK_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(600);
+
+    let mut ticker = tokio::time::interval(Duration::from_millis(poll_ms));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    tracing::info!(
+        poll_ms,
+        max_attempts,
+        max_stuck_secs,
+        "reconnect watchdog started"
+    );
+
+    loop {
+        ticker.tick().await;
+        for (session_id, runtime) in state.session_iter_with_ids() {
+            if runtime.get_status() != SessionStatus::Connecting {
+                continue;
+            }
+            let Some(client) = runtime.get_client() else {
+                continue;
+            };
+            let stuck_secs = runtime.reconnecting_for_secs().unwrap_or(0);
+            let reconnect_errors = client.stats().reconnect_errors;
+            if reconnect_errors < max_attempts && stuck_secs < max_stuck_secs {
+                continue;
+            }
+
+            tracing::warn!(
+                session_id = %session_id,
+                reconnect_errors,
+                stuck_secs,
+                "reconnect watchdog: forcing full rebuild after a stuck retry window"
+            );
+
+            client.disconnect().await;
+            runtime.set_client(None);
+            runtime.set_status(SessionStatus::Disconnected);
+            runtime.clear_reconnecting();
+            let _ = state
+                .session_manager()
+                .update_session_status(&session_id, SessionStatus::Disconnected, false)
+                .await;
+
+            let payload = serde_json::json!({
+                "session_id": session_id,
+                "event": "disconnected",
+                "timestamp": chrono::Utc::now().timestamp(),
+                "data": { "forced_by": "reconnect_watchdog" },
+            });
+            if let Ok(payload_str) = serde_json::to_string(&payload) {
+                state
+                    .broadcast_to_webhooks(&session_id, "disconnected", &payload_str)
+                    .await;
+                state
+                    .publish_to_nats(&session_id, "disconnected", &payload_str)
+                    .await;
+                runtime.broadcast_event(payload_str);
+            }
+
+            runtime.set_status(SessionStatus::Connecting);
+            let state_clone = state.clone();
+            let session_id_clone = session_id.clone();
+            tokio::spawn(async move {
+                if let Err(e) = connect_client(&state_clone, &session_id_clone, None).await {
+                    tracing::error!(
+                        "reconnect watchdog: rebuild failed for {}: {}",
+                        session_id_clone,
+                        e
+                    );
+                    if let Some(rt) = state_clone.get_session(&session_id_clone) {
+                        rt.set_status(SessionStatus::Disconnected);
+                        rt.set_client(None);
+                    }
+                }
+            });
+        }
+    }
+}
+
 async fn connect_client(
     state: &AppState,
     session_id: &str,
@@ -1190,6 +1313,7 @@ async fn handle_event(
             runtime.set_qr_codes(vec![]);
             runtime.set_pair_code(None);
             runtime.clear_pair_state();
+            runtime.clear_reconnecting();
 
             let push_name_str = client.push_name();
             let push_name = if push_name_str.is_empty() {
@@ -1229,6 +1353,11 @@ async fn handle_event(
                 );
             }
             runtime.set_status(SessionStatus::Connecting);
+            runtime.mark_reconnecting_now();
+            let _ = state
+                .session_manager()
+                .update_session_status(session_id, SessionStatus::Connecting, false)
+                .await;
         }
         Event::LoggedOut(logged_out) => {
             if let Some(client) = runtime.get_client() {
@@ -1236,6 +1365,7 @@ async fn handle_event(
             }
             runtime.set_status(SessionStatus::Disconnected);
             runtime.set_client(None);
+            runtime.clear_reconnecting();
             let _ = state
                 .session_manager()
                 .update_session_status(session_id, SessionStatus::Disconnected, false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,13 @@
 //!   milliseconds (default 1000).
 //! - `MESSAGE_HISTORY_ENABLED` — set to `false` to disable best-effort
 //!   message-history ingestion (the search index; default true).
+//! - `RECONNECT_WATCHDOG_POLL_MS` — reconnect watchdog tick interval in
+//!   milliseconds (default 30000).
+//! - `RECONNECT_MAX_ATTEMPTS` — consecutive reconnect failures before the
+//!   watchdog forces a full client rebuild (default 10).
+//! - `RECONNECT_MAX_STUCK_SECS` — seconds a session may sit in
+//!   `Connecting` before the watchdog forces a rebuild, regardless of the
+//!   attempt count (default 600).
 //!
 //! ## Storage
 //!
@@ -808,6 +815,11 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
     let reconnect_state = state.clone();
     tokio::spawn(async move {
         handlers::sessions::reconnect_all_on_startup(reconnect_state).await;
+    });
+
+    let watchdog_state = state.clone();
+    tokio::spawn(async move {
+        handlers::sessions::run_reconnect_watchdog(watchdog_state).await;
     });
 
     let scheduler_state = state.clone();

--- a/src/state.rs
+++ b/src/state.rs
@@ -78,6 +78,17 @@ pub struct SessionState {
     /// show users meaningful progress and last-error text instead of
     /// guessing from polling QR codes.
     pub pair_state: RwLock<PairState>,
+
+    /// Unix timestamp of the start of the *current* unplanned reconnect
+    /// window, set when `Event::Disconnected` fires and cleared on the next
+    /// `Event::Connected` (or when the session goes away entirely via
+    /// `Event::LoggedOut`). `None` means "not currently retrying" -- either
+    /// genuinely connected, or never connected in the first place. The
+    /// reconnect watchdog ([`crate::handlers::sessions::run_reconnect_watchdog`])
+    /// reads this to decide when a session has been stuck retrying for too
+    /// long and needs a forced full rebuild rather than waiting on
+    /// whatsapp-rust's own backoff indefinitely.
+    pub reconnecting_since: RwLock<Option<i64>>,
 }
 
 /// Snapshot of the latest pair attempt for a session. Lives entirely in
@@ -103,7 +114,26 @@ impl SessionState {
             storage_path,
             logout_history: RwLock::new(Vec::new()),
             pair_state: RwLock::new(PairState::default()),
+            reconnecting_since: RwLock::new(None),
         }
+    }
+
+    pub fn mark_reconnecting_now(&self) {
+        let mut slot = self.reconnecting_since.write();
+        if slot.is_none() {
+            *slot = Some(chrono::Utc::now().timestamp());
+        }
+    }
+
+    pub fn clear_reconnecting(&self) {
+        *self.reconnecting_since.write() = None;
+    }
+
+    /// Seconds since the current unplanned reconnect window started, or
+    /// `None` if not currently in one.
+    pub fn reconnecting_for_secs(&self) -> Option<i64> {
+        let since = (*self.reconnecting_since.read())?;
+        Some((chrono::Utc::now().timestamp() - since).max(0))
     }
 
     /// Record a LoggedOut event and return whether the session has crossed
@@ -690,6 +720,19 @@ impl AppState {
             .collect()
     }
 
+    /// Same as [`Self::session_iter`], but keeping each runtime's session
+    /// id alongside it -- needed by anything that has to act back on a
+    /// specific session (e.g. the reconnect watchdog calling
+    /// [`crate::handlers::sessions::connect_client`]), since
+    /// [`SessionState`] doesn't carry its own id.
+    pub fn session_iter_with_ids(&self) -> Vec<(String, Arc<SessionState>)> {
+        self.inner
+            .sessions
+            .iter()
+            .map(|r| (r.key().clone(), r.value().clone()))
+            .collect()
+    }
+
     #[allow(dead_code)]
     pub fn has_session(&self, session_id: &str) -> bool {
         self.inner.sessions.contains_key(session_id)
@@ -872,5 +915,42 @@ impl AppState {
                 }
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnecting_since_starts_unset() {
+        let s = SessionState::new("/tmp/x".to_string());
+        assert_eq!(s.reconnecting_for_secs(), None);
+    }
+
+    #[test]
+    fn mark_reconnecting_is_idempotent() {
+        let s = SessionState::new("/tmp/x".to_string());
+        s.mark_reconnecting_now();
+        let first = *s.reconnecting_since.read();
+        assert!(first.is_some());
+
+        s.mark_reconnecting_now();
+        let second = *s.reconnecting_since.read();
+        assert_eq!(
+            first, second,
+            "a second mark while already reconnecting must not reset the window start"
+        );
+        assert!(s.reconnecting_for_secs().is_some());
+    }
+
+    #[test]
+    fn clear_reconnecting_resets_to_none() {
+        let s = SessionState::new("/tmp/x".to_string());
+        s.mark_reconnecting_now();
+        assert!(s.reconnecting_for_secs().is_some());
+
+        s.clear_reconnecting();
+        assert_eq!(s.reconnecting_for_secs(), None);
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,6 +28,8 @@ pub struct Harness {
     pub app: Router,
     #[allow(dead_code)]
     pub pool: DbPool,
+    #[allow(dead_code)]
+    pub state: AppState,
     pub _tmp: TempDir,
 }
 
@@ -52,11 +54,12 @@ impl Harness {
                 state.clone(),
                 middleware::jwt::jwt_auth_middleware,
             ))
-            .with_state(state);
+            .with_state(state.clone());
 
         Self {
             app,
             pool,
+            state,
             _tmp: tmp,
         }
     }

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -113,6 +113,50 @@ async fn get_session_returns_stored_row() {
     assert_eq!(body.get("name").and_then(|v| v.as_str()), Some("Gettable"));
 }
 
+/// `GET /sessions/{id}` (singular) used to trust the raw cached status with
+/// no reconciliation, unlike `GET /sessions` (list) and `GET
+/// /sessions/{id}/status`, which both degrade a cached `logged_in` back to
+/// `connecting` when the socket isn't actually alive. That gap meant the
+/// same session could report `logged_in` from one endpoint and `connecting`
+/// from another at the same instant -- reproduced here by setting the
+/// runtime's cached status to `LoggedIn` with no live client attached
+/// (exactly what's left behind when a socket dies without the crate ever
+/// dispatching a disconnect event) and asserting the singular endpoint
+/// degrades it the same way the others already did.
+#[tokio::test]
+async fn get_session_reconciles_stale_logged_in_status_with_no_live_client() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-stale"}),
+        ),
+    )
+    .await;
+
+    let runtime = h.state.get_or_create_session("s-stale", "/tmp/s-stale");
+    runtime.set_status(waxum::models::sessions::SessionStatus::LoggedIn);
+
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-stale", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.get("status").and_then(|v| v.as_str()),
+        Some("connecting"),
+        "a cached logged_in status with no live client must degrade, not report stale: {body:?}"
+    );
+    assert_eq!(
+        body.get("is_logged_in").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+}
+
 #[tokio::test]
 async fn list_after_creates_returns_all_rows() {
     let h = Harness::new().await;


### PR DESCRIPTION
## Summary

Auto-reconnect was enabled but could get stuck instead of re-establishing the socket after a drop. Three root causes, all fixed:

- **Zombie client race**: `connect_session` cleared its `Arc<Client>` slot before rebuilding but never called `client.disconnect()` on whatever was still there — the old client's background task (and its own internal reconnect loop) kept running against the *same on-disk device store*, so a manual reconnect could spawn a second `Client` fighting the first. Now disconnects the old client cleanly first, every time.
- **409 deadlock**: `connect_session` refused to act while status was `Connecting` — exactly the state a session sits in for the entire duration of whatsapp-rust's internal backoff after a drop, with no way to force a clean rebuild during the one window it's needed. `Connecting` no longer blocks a reconnect request (`WaitingForQr`/`WaitingForPairCode` still do, so an in-progress pairing flow isn't clobbered).
- **Status honesty**: `Event::Disconnected` never persisted to the DB (every sibling transition did), and `GET /sessions/{id}` (singular) used the raw cached status with no reconciliation against the live socket, unlike `GET /sessions` (list) and `GET /sessions/{id}/status` — so the same session could report `logged_in` from one endpoint and `connecting` from another at the same instant. Both fixed.

**New: self-heal watchdog.** whatsapp-rust's own reconnect loop has no attempt cap of its own — it backs off up to 15 minutes between tries, forever. A new watchdog (`RECONNECT_WATCHDOG_POLL_MS`, default 30s) forces a full rebuild once a session has been retrying past `RECONNECT_MAX_ATTEMPTS` (default 10) or `RECONNECT_MAX_STUCK_SECS` (default 600s), plus broadcasts a synthetic `disconnected` webhook/event as a safety net for sockets that die without whatsapp-rust ever dispatching one.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (81 tests, all passing — new coverage for the reconnecting-timer state logic and the `get_session` status-reconciliation gap)
- [x] `cargo build`