### PR TITLE
v0.11.2 — fix Docker: chown volumes so pre-0.11.0 upgrades keep working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.11.2] - 2026-07-28
+
+### Fixed — Docker: regression from the 0.11.0 non-root user broke upgrades
+
+0.11.0 added a non-root `waxum` user (uid/gid 1000) to the Docker image
+(the OWASP hardening pass). That's correct for a *fresh* deployment, but
+broke every *existing* one: volumes created by pre-0.11.0 images (which
+ran as root) are owned by uid 0, and the new non-root process couldn't
+write to them — `attempt to write a readonly database` on the SQLite
+file, sessions unreadable.
+
+Fixed with the standard pattern for this exact problem (the same one
+Postgres/MySQL/Grafana's official images use): the container now starts
+as root, a new `docker-entrypoint.sh` `chown -R`s `WHATSAPP_STORAGE_PATH`
+(and the directory holding `SQLITE_PATH`, if that's set to somewhere
+else) so pre-existing root-owned volume contents become writable by
+`waxum` again, then drops privileges via `gosu waxum:waxum` before
+actually exec'ing the binary. The app process itself is still never
+root -- only the brief chown-on-start step is -- so this keeps the
+0.11.0 hardening intact while fixing the upgrade path. No action needed
+on existing deployments; pulling the new image and restarting the
+container self-heals the ownership.
+
 ## [0.11.1] - 2026-07-28
 
 ### Fixed — auto-reconnect actually re-establishes the socket, honest status, self-heal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,15 +38,18 @@ RUN apt-get update && apt-get install -y \
     libssl3 \
     libsqlite3-0 \
     curl \
+    gosu \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/*
 
 COPY --from=rust-builder /app/target/release/waxum /app/waxum
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 
 RUN mkdir -p /app/whatsapp_sessions \
     && groupadd --system --gid 1000 waxum \
     && useradd --system --uid 1000 --gid waxum --no-create-home --shell /usr/sbin/nologin waxum \
-    && chown -R waxum:waxum /app
+    && chown -R waxum:waxum /app \
+    && chmod +x /app/docker-entrypoint.sh
 
 ENV WHATSAPP_STORAGE_PATH=/app/whatsapp_sessions
 ENV RUST_LOG=waxum=info,tower_http=info
@@ -56,6 +59,10 @@ EXPOSE 3451
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD curl -fsS --max-time 4 http://127.0.0.1:3451/health || exit 1
 
-USER waxum:waxum
-
+# No `USER waxum` here: the container starts as root so the entrypoint can
+# chown mounted volumes (which may still be owned by root from a
+# pre-0.11.1 image) before dropping to the unprivileged `waxum` user via
+# gosu to actually run the binary. The process that ends up running the
+# app is never root -- only the brief setup step is.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["/app/waxum"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# Runs once per container start, as root (the image's default user --
+# `USER waxum` was removed from the Dockerfile specifically so this step
+# has permission to run). Existing deployments have volumes created by
+# pre-0.11.1 images, which ran as root: `chown -R waxum` on every start
+# is what lets those keep working after upgrading to a non-root image,
+# without an operator having to manually fix permissions on the host.
+# Cheap on repeat runs -- chown is a no-op once ownership already matches.
+
+storage_dir="${WHATSAPP_STORAGE_PATH:-/app/whatsapp_sessions}"
+mkdir -p "$storage_dir"
+chown -R waxum:waxum "$storage_dir"
+
+if [ -n "${SQLITE_PATH:-}" ]; then
+    sqlite_dir=$(dirname "$SQLITE_PATH")
+    mkdir -p "$sqlite_dir"
+    chown -R waxum:waxum "$sqlite_dir"
+fi
+
+exec gosu waxum:waxum "$@"


### PR DESCRIPTION
## Summary

Closes #59. Regression from 0.11.0's non-root Docker user: existing deployments (volumes created by pre-0.11.0 root-run images) couldn't write to their own SQLite DB after upgrading — `attempt to write a readonly database`, sessions unreadable. Confirmed via SSH on a live instance (new image uid=1000 waxum, old image uid=0 root, volume files owned 0:0).

Fixed with the standard pattern (same one Postgres/MySQL/Grafana's official images use): the container now starts as root, a new `docker-entrypoint.sh` `chown -R`s `WHATSAPP_STORAGE_PATH` (and `SQLITE_PATH`'s directory, if set separately) so pre-existing root-owned volume contents become writable by `waxum` again, then drops to `gosu waxum:waxum` before exec'ing the binary. The app process itself is still never root — 0.11.0's hardening stays intact, only the upgrade path is fixed. Self-heals on restart, no manual `chown` needed on the host.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build`
- [x] Shell syntax-checked (`sh -n docker-entrypoint.sh`)
- [ ] Docker build/run not verified in this environment (no `docker` available) — verify on a real host before/after merge: pull 0.11.2 over an existing root-owned volume and confirm the SQLite write error is gone.