### PR TITLE
v0.11.3 — bump vendored whatsapp-rust (dde51e7a -> 13fce2f0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.11.3] - 2026-07-31
+
+### Changed — bumped vendored `whatsapp-rust` (`dde51e7a` → `13fce2f0`, ~60 commits)
+
+No waxum source changes needed; build, clippy, and the full test suite
+pass unchanged against the new rev. Highlights relevant to this app:
+
+- **`fix(lifecycle): race the reconnect backoff against the terminal
+  shutdown` (#1179).** Previously `Client::disconnect()` did not wake an
+  in-progress reconnect backoff sleep — with the Fibonacci backoff capped
+  at 900s, a disconnect issued while the client was deep in that sleep
+  could take up to 15 minutes to actually take effect. This directly
+  strengthens [0.11.1]'s `run_reconnect_watchdog`: its forced-rebuild path
+  calls `client.disconnect().await` synchronously inside the watchdog's
+  poll loop, so before this upstream fix a wedged client could stall the
+  watchdog's checks for *every other session* for up to 15 minutes. Now
+  `disconnect()` returns promptly regardless of backoff state.
+- `feat(voip): add group calls and call links` (#1130).
+- `feat(download): allow media download without a connected session`
+  (#1194), plus `fix(download): guarantee download_to_writer leaves only
+  verified media` (#1197).
+- `fix(pair-code): keep a phone-number link alive past QR rotation`
+  (#1163), `fix(pair-code): read the companion_finish answer instead of
+  assuming it` (#1198), `feat(pair-code): report a refused pair-code
+  request to the consumer` (#1191).
+- `fix(appstate): let a diverged collection converge, and stop losing
+  409'd patches` (#1158).
+- A batch of JID/AD-JID identity fixes affecting device dedup (#1178,
+  #1182, #1184).
+- Numerous `perf(*)` commits (JID parsing, noise-frame coalescing,
+  per-message allocation cuts) — no behavior change expected.
+
 ## [0.11.2] - 2026-07-28
 
 ### Fixed — Docker: regression from the 0.11.0 non-root user broke upgrades

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "bytes",
  "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
@@ -42,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -72,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead 0.6.1",
- "aes 0.9.1",
+ "aes 0.9.2",
  "cipher 0.5.2",
  "ctr 0.10.1",
  "ghash 0.6.0",
@@ -141,12 +140,6 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "asn1-rs"
@@ -564,12 +557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1255,27 +1242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "diesel"
 version = "2.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,13 +1314,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1436,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1488,11 +1454,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1879,9 +1844,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "equivalent",
-]
 
 [[package]]
 name = "heck"
@@ -1939,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1984,9 +1946,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -3649,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4459,13 +4421,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4629,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -4800,26 +4762,6 @@ name = "twox-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
-
-[[package]]
-name = "typed-builder"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "typenum"
@@ -5025,9 +4967,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "wacore"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "aes-gcm 0.11.0",
  "anyhow",
  "async-channel",
@@ -5042,7 +4984,6 @@ dependencies = [
  "compact_str",
  "ctr 0.10.1",
  "event-listener",
- "flate2",
  "futures",
  "hashbrown 0.17.1",
  "hex",
@@ -5058,11 +4999,11 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "smallvec",
  "smoothutf8",
  "subtle",
  "thiserror 2.0.19",
  "tracing",
- "typed-builder",
  "wacore-appstate",
  "wacore-binary",
  "wacore-derive",
@@ -5070,16 +5011,16 @@ dependencies = [
  "wacore-noise",
  "waproto",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
 name = "wacore-appstate"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "anyhow",
  "buffa",
- "bytemuck",
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",
@@ -5097,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "bytes",
  "compact_str",
@@ -5114,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "wacore-derive"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5124,10 +5065,9 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
- "aes 0.9.1",
- "arrayref",
+ "aes 0.9.2",
  "async-lock",
  "async-trait",
  "buffa",
@@ -5136,8 +5076,6 @@ dependencies = [
  "chrono",
  "ctr 0.10.1",
  "curve25519-dalek 5.0.0",
- "derive_more",
- "displaydoc",
  "ghash 0.6.0",
  "hex",
  "hkdf 0.13.0",
@@ -5150,7 +5088,6 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.19",
- "uuid",
  "wacore-derive",
  "waproto",
  "x25519-dalek 3.0.0",
@@ -5159,7 +5096,7 @@ dependencies = [
 [[package]]
 name = "wacore-noise"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5196,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -5526,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5550,6 +5487,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "smallvec",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5564,12 +5502,13 @@ dependencies = [
  "whatsapp-rust-sqlite-storage",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
+ "zeroize",
 ]
 
 [[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "async-trait",
  "buffa",
@@ -5589,7 +5528,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-tokio-transport"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5609,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=dde51e7ac1e072b93f7af58b4bc7f69e2c84503e#dde51e7ac1e072b93f7af58b4bc7f69e2c84503e"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -10,13 +10,13 @@ repository = "https://github.com/imtaqin/waxum"
 [dependencies]
 
 rand = "0.8"
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e", default-features = true, features = ["voip", "tracing"] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
-whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "dde51e7ac1e072b93f7af58b4bc7f69e2c84503e" }
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84", default-features = true, features = ["voip", "tracing"] }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
+whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
 
 # Web framework
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }


### PR DESCRIPTION
## Summary
- Bumps the vendored `oxidezap/whatsapp-rust` pin ~60 commits forward (`dde51e7a` → `13fce2f0`). No waxum source changes were needed — `fmt`, `clippy -D warnings`, and the full test suite pass unchanged against the new rev.
- Most relevant upstream fix: **`fix(lifecycle): race the reconnect backoff against the terminal shutdown` (#1179)**. Before this, `Client::disconnect()` did not wake an in-progress reconnect backoff sleep, so a disconnect issued while the client was parked deep in the Fibonacci backoff (capped at 900s) could take up to 15 minutes to take effect. This directly strengthens the [0.11.1] `run_reconnect_watchdog`: its forced-rebuild path calls `client.disconnect().await` synchronously inside the watchdog's poll loop, so a wedged client could previously stall the watchdog's checks for *every other session* for up to 15 minutes. Now `disconnect()` returns promptly regardless of backoff state.
- Also picks up: group calls + call links (#1130), media download without a connected session (#1194) + guaranteed-verified `download_to_writer` (#1197), several pair-code robustness fixes (#1163, #1191, #1198), an appstate patch-convergence fix (#1158), and a batch of JID/AD-JID identity fixes affecting device dedup (#1178, #1182, #1184).

## Test plan
- [x] `cargo build -j 4` — clean, no source changes required
- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --all-targets -j 4 -- -D warnings` — pass, 0 warnings
- [x] `cargo test -j 4` — full suite green (unit + all integration test files)
- [ ] Not verified against a live WhatsApp connection in this environment — recommend watching a canary deployment's reconnect behavior after this ships