### PR TITLE
v0.11.4 — bump vendored whatsapp-rust (13fce2f0 -> 2b607618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.11.4] - 2026-08-06
+
+### Changed — bumped vendored `whatsapp-rust` (`13fce2f0` → `2b607618`, 9 commits)
+
+No waxum source changes needed; build, clippy, and the full test suite
+pass unchanged against the new rev. Highlights:
+
+- **`fix(appstate): unbreak the bootstrap gate and read the right lifecycle
+  signals` (#1208).** The largest change in this batch — reworks
+  `Client`'s lifecycle signaling. Introduces `is_terminal()`, which finally
+  separates "this connection ended" from "this client is done for good"
+  (the old `is_shutting_down` conflated both, so code waiting across a
+  reconnect could give up right when the replacement connection was about
+  to land). Adds a `session_state_notifier` so anything parked waiting on
+  connection state wakes promptly on every terminal transition, and an
+  `authenticated_generation` guard so a request can't be admitted under a
+  connection generation that's already been retired.
+- `fix(appstate): report what a batched sync actually achieved` (#1207) —
+  batched appstate sync now reports its real outcome instead of assuming
+  success.
+- `fix(appstate): reserve the collection for an AppStateSync task` (#1205).
+- `fix(history-sync): match our own pushname entry by JID user` (#1203).
+- `fix(libsignal): keep skipped message-key seeds projectable` (#1210) —
+  ratchet/session-state fix around skipped message keys.
+- `feat(libsignal): let a consumer opt out of counter leasing` (#1211).
+- `bench(libsignal): sender-key XEdDSA memo benchmark` (#1212) — bench
+  only, no behavior change.
+- `ci(test): run the suites through cargo-nextest` (#1209) — upstream CI
+  only, not applicable here.
+
 ## [0.11.3] - 2026-07-31
 
 ### Changed — bumped vendored `whatsapp-rust` (`dde51e7a` → `13fce2f0`, ~60 commits)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -110,9 +110,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -2181,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -2324,9 +2324,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4349,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4967,7 +4967,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "wacore"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.0",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "wacore-appstate"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "bytes",
  "compact_str",
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "wacore-derive"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "aes 0.9.2",
  "async-lock",
@@ -5096,7 +5096,7 @@ dependencies = [
 [[package]]
 name = "wacore-noise"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5133,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.11.2"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5508,7 +5508,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "async-trait",
  "buffa",
@@ -5528,7 +5528,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-tokio-transport"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
 version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=13fce2f07dd9c6802716401b7b3841af48909a84#13fce2f07dd9c6802716401b7b3841af48909a84"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6017,9 +6017,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -10,13 +10,13 @@ repository = "https://github.com/imtaqin/waxum"
 [dependencies]
 
 rand = "0.8"
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84", default-features = true, features = ["voip", "tracing"] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
-whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "13fce2f07dd9c6802716401b7b3841af48909a84" }
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3", default-features = true, features = ["voip", "tracing"] }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
+whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
 
 # Web framework
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }


### PR DESCRIPTION
## Summary
- Bumps the vendored `whatsapp-rust` git rev from `13fce2f0` to `2b607618` (9 upstream commits) across all 7 pinned crates.
- No waxum source changes required — build, `fmt --check`, `clippy -D warnings`, and the full test suite all pass unchanged against the new rev.
- `waxum` version 0.11.3 -> 0.11.4.

## Notable upstream changes
- **`fix(appstate): unbreak the bootstrap gate and read the right lifecycle signals` (#1208)** — the biggest change here. Reworks `Client` lifecycle signaling: adds `is_terminal()` to properly distinguish "this connection ended" from "this client is done for good" (previously conflated by `is_shutting_down`), a `session_state_notifier` for prompt wakeups on terminal transitions, and an `authenticated_generation` guard preventing requests from being admitted under a stale connection generation.
- `fix(appstate): report what a batched sync actually achieved` (#1207)
- `fix(appstate): reserve the collection for an AppStateSync task` (#1205)
- `fix(history-sync): match our own pushname entry by JID user` (#1203)
- `fix(libsignal): keep skipped message-key seeds projectable` (#1210)
- `feat(libsignal): let a consumer opt out of counter leasing` (#1211)
- `bench(libsignal)` (#1212) and `ci(test)` (#1209) — no functional impact.

## Test plan
- [x] `cargo build -j 4` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -j 4` — all suites pass, 0 failures
- [ ] Not verified against a live WhatsApp connection (sandboxed environment)