### PR TITLE
v0.11.5 — chat-scoped message listing with push_name + media pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 All notable changes to **waxum** will be documented in this file.
 
-## [0.11.4] - 2026-08-06
+## [0.11.5] - 2026-08-06
+
+### Added — `GET /sessions/{id}/messages/chat/{chat_jid}`
+
+A plain "show me this chat" read, the counterpart to
+`/messages/search` for callers that don't have (or don't want to
+require) a search term — built for the WhatsApp MCP server. Newest
+first, paginated (`limit`/`offset`), no query text required.
+
+- Each row now carries the sender's `push_name` (joined from
+  `contacts`) and, for media messages, a `media` download pointer
+  (`media_key`, `file_sha256`, `file_enc_sha256`, `direct_path`,
+  `file_length`, `media_type`, `mimetype`) shaped to pass straight
+  into `POST /media/download` with no re-encoding.
+- The `messages` table gained seven columns to make the media
+  pointer persistable — previously nothing about a media message's
+  download parameters survived past the original event, so a past
+  message was never downloadable again once the live event handler
+  moved on. Migrated across all three backends (SQLite 3.35+, Postgres,
+  MySQL), tolerant of already-migrated databases.
+- `/messages/search` is unchanged — its rows still carry `push_name:
+  null` and `media: null`; only the new chat-listing endpoint
+  populates them.
 
 ### Changed — bumped vendored `whatsapp-rust` (`13fce2f0` → `2b607618`, 9 commits)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/db/messages.rs
+++ b/src/db/messages.rs
@@ -61,13 +61,41 @@ pub struct NewMessage {
     /// Searchable text: message body, or the caption for media.
     pub body: Option<String>,
     pub msg_timestamp: chrono::DateTime<chrono::Utc>,
+    /// Download pointers for media message types, `None` for
+    /// text/location/contact/etc. All base64-encoded except
+    /// `direct_path`, `media_type`, and `mimetype` — the same shapes
+    /// [`crate::models::media::DownloadMediaRequest`] expects, so a
+    /// caller can round-trip these fields straight into
+    /// `POST /media/download` with no re-encoding.
+    pub media: Option<MediaPointer>,
 }
 
-/// A `messages` row as returned by search, timestamps rendered as
-/// `%Y-%m-%d %H:%M:%S` UTC text regardless of backend. `snippet` is
-/// only populated by backends with cheap highlight support (SQLite
-/// FTS5, Postgres).
-#[derive(Debug, Clone)]
+/// Download pointer for one media message, captured at ingestion time
+/// since `/media/download` needs the encryption key and hashes that
+/// only exist on the original message — they are never re-derivable
+/// from a stored history row otherwise.
+#[derive(Debug, Clone, Default)]
+pub struct MediaPointer {
+    pub media_key: String,
+    pub file_sha256: String,
+    pub file_enc_sha256: String,
+    pub direct_path: String,
+    pub file_length: i64,
+    /// One of `image`, `video`, `audio`, `document`, `sticker` —
+    /// matches `crate::models::media::MediaType`'s snake_case wire
+    /// form.
+    pub media_type: String,
+    pub mimetype: String,
+}
+
+/// A `messages` row as returned by search or chat listing, timestamps
+/// rendered as `%Y-%m-%d %H:%M:%S` UTC text regardless of backend.
+/// `snippet` is only populated by backends with cheap highlight
+/// support (SQLite FTS5, Postgres) and only by [`search`]. `media` and
+/// `push_name` are only populated by [`list_by_chat`] — `search`'s
+/// queries don't select those columns, so its rows always carry
+/// `None` there.
+#[derive(Debug, Clone, Default)]
 pub struct MessageRow {
     pub id: i64,
     pub message_id: String,
@@ -79,6 +107,8 @@ pub struct MessageRow {
     pub body: Option<String>,
     pub msg_timestamp: String,
     pub snippet: Option<String>,
+    pub media: Option<MediaPointer>,
+    pub push_name: Option<String>,
 }
 
 /// Store one message, ignoring duplicates on `(session_id,
@@ -87,12 +117,21 @@ pub struct MessageRow {
 /// when the row was actually new; FTS-insert errors are swallowed so a
 /// broken index never blocks ingestion.
 pub async fn insert(pool: &DbPool, msg: &NewMessage) -> anyhow::Result<()> {
+    let media = msg.media.as_ref();
+    let media_key = media.map(|m| m.media_key.as_str());
+    let file_sha256 = media.map(|m| m.file_sha256.as_str());
+    let file_enc_sha256 = media.map(|m| m.file_enc_sha256.as_str());
+    let direct_path = media.map(|m| m.direct_path.as_str());
+    let file_length = media.map(|m| m.file_length);
+    let media_type = media.map(|m| m.media_type.as_str());
+    let mimetype = media.map(|m| m.mimetype.as_str());
+
     match pool {
         DbPool::Postgres(pg) => {
             let client = pg.get().await?;
             client
                 .execute(
-                    "INSERT INTO messages (message_id, session_id, chat_jid, sender_jid, direction, msg_type, body, msg_timestamp) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) ON CONFLICT (session_id, message_id) DO NOTHING",
+                    "INSERT INTO messages (message_id, session_id, chat_jid, sender_jid, direction, msg_type, body, msg_timestamp, media_key, file_sha256, file_enc_sha256, direct_path, file_length, media_type, mimetype) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) ON CONFLICT (session_id, message_id) DO NOTHING",
                     &[
                         &msg.message_id,
                         &msg.session_id,
@@ -102,28 +141,44 @@ pub async fn insert(pool: &DbPool, msg: &NewMessage) -> anyhow::Result<()> {
                         &msg.msg_type,
                         &msg.body,
                         &msg.msg_timestamp,
+                        &media_key,
+                        &file_sha256,
+                        &file_enc_sha256,
+                        &direct_path,
+                        &file_length,
+                        &media_type,
+                        &mimetype,
                     ],
                 )
                 .await?;
         }
         DbPool::MySQL(my) => {
             use mysql_async::prelude::*;
+            use mysql_async::Value as MyValue;
             let mut conn = my.get_conn().await?;
             let ts = fmt_utc(msg.msg_timestamp);
             let now = now_str();
+            let params: Vec<MyValue> = vec![
+                msg.message_id.clone().into(),
+                msg.session_id.clone().into(),
+                msg.chat_jid.clone().into(),
+                msg.sender_jid.clone().into(),
+                msg.direction.clone().into(),
+                msg.msg_type.clone().into(),
+                msg.body.clone().into(),
+                ts.into(),
+                now.into(),
+                media_key.map(str::to_string).into(),
+                file_sha256.map(str::to_string).into(),
+                file_enc_sha256.map(str::to_string).into(),
+                direct_path.map(str::to_string).into(),
+                file_length.into(),
+                media_type.map(str::to_string).into(),
+                mimetype.map(str::to_string).into(),
+            ];
             conn.exec_drop(
-                "INSERT IGNORE INTO messages (message_id, session_id, chat_jid, sender_jid, direction, msg_type, body, msg_timestamp, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
-                (
-                    &msg.message_id,
-                    &msg.session_id,
-                    &msg.chat_jid,
-                    &msg.sender_jid,
-                    &msg.direction,
-                    &msg.msg_type,
-                    msg.body.as_deref(),
-                    ts,
-                    now,
-                ),
+                "INSERT IGNORE INTO messages (message_id, session_id, chat_jid, sender_jid, direction, msg_type, body, msg_timestamp, created_at, media_key, file_sha256, file_enc_sha256, direct_path, file_length, media_type, mimetype) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                mysql_async::Params::Positional(params),
             )
             .await?;
         }
@@ -131,10 +186,20 @@ pub async fn insert(pool: &DbPool, msg: &NewMessage) -> anyhow::Result<()> {
             let m = msg.clone();
             let ts = fmt_utc(m.msg_timestamp);
             let now = now_str();
+            let media_key = media_key.map(str::to_string);
+            let file_sha256 = file_sha256.map(str::to_string);
+            let file_enc_sha256 = file_enc_sha256.map(str::to_string);
+            let direct_path = direct_path.map(str::to_string);
+            let media_type = media_type.map(str::to_string);
+            let mimetype = mimetype.map(str::to_string);
             sqlite_blocking(handle, move |conn| {
+                let file_length_value = match file_length {
+                    Some(n) => SQ::Int(n),
+                    None => SQ::Null,
+                };
                 let changed = sqlite_raw::execute(
                     conn,
-                    "INSERT OR IGNORE INTO messages (message_id, session_id, chat_jid, sender_jid, direction, msg_type, body, msg_timestamp, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                    "INSERT OR IGNORE INTO messages (message_id, session_id, chat_jid, sender_jid, direction, msg_type, body, msg_timestamp, created_at, media_key, file_sha256, file_enc_sha256, direct_path, file_length, media_type, mimetype) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                     &[
                         SQ::Text(m.message_id.clone()),
                         SQ::Text(m.session_id.clone()),
@@ -145,6 +210,13 @@ pub async fn insert(pool: &DbPool, msg: &NewMessage) -> anyhow::Result<()> {
                         SQ::from_opt_str(m.body.as_deref()),
                         SQ::Text(ts),
                         SQ::Text(now),
+                        SQ::from_opt_str(media_key.as_deref()),
+                        SQ::from_opt_str(file_sha256.as_deref()),
+                        SQ::from_opt_str(file_enc_sha256.as_deref()),
+                        SQ::from_opt_str(direct_path.as_deref()),
+                        file_length_value,
+                        SQ::from_opt_str(media_type.as_deref()),
+                        SQ::from_opt_str(mimetype.as_deref()),
                     ],
                 )?;
                 if changed > 0 {
@@ -280,6 +352,61 @@ pub async fn search(
     }
 }
 
+/// List one chat's history, newest first, no search term required —
+/// the counterpart to [`search`] for a plain "show me this chat"
+/// read. Rows carry the media download pointer (when the message was
+/// media) and the sender's `push_name` via a `LEFT JOIN` against
+/// `contacts`, both `None`/absent from [`search`]'s rows.
+///
+/// Every column across the join is qualified (`m.`/`c.`) even though
+/// today's `contacts`/`messages` schemas don't collide outside
+/// `session_id` — the FTS join already bit this project once with an
+/// "ambiguous column name" failure (see `tests/fts_probe.rs`), so new
+/// joins qualify unconditionally rather than relying on the current
+/// column set staying disjoint.
+pub async fn list_by_chat(
+    pool: &DbPool,
+    session_id: &str,
+    chat_jid: &str,
+    limit: i64,
+    offset: i64,
+) -> anyhow::Result<Vec<MessageRow>> {
+    let session_id = session_id.to_string();
+    let chat_jid = chat_jid.to_string();
+    match pool {
+        DbPool::Postgres(pg) => {
+            let client = pg.get().await?;
+            let sql = "SELECT m.id, m.message_id, m.session_id, m.chat_jid, m.sender_jid, m.direction, m.msg_type, m.body, m.msg_timestamp, m.media_key, m.file_sha256, m.file_enc_sha256, m.direct_path, m.file_length, m.media_type, m.mimetype, c.push_name FROM messages m LEFT JOIN contacts c ON c.session_id = m.session_id AND c.jid = m.sender_jid WHERE m.session_id = $1 AND m.chat_jid = $2 ORDER BY m.msg_timestamp DESC, m.id DESC LIMIT $3 OFFSET $4";
+            let rows = client
+                .query(sql, &[&session_id, &chat_jid, &limit, &offset])
+                .await?;
+            Ok(rows.iter().map(pg_row_to_chat_message).collect())
+        }
+        DbPool::MySQL(my) => {
+            use mysql_async::prelude::*;
+            let mut conn = my.get_conn().await?;
+            let sql = "SELECT m.id, m.message_id, m.session_id, m.chat_jid, m.sender_jid, m.direction, m.msg_type, m.body, m.msg_timestamp, m.media_key, m.file_sha256, m.file_enc_sha256, m.direct_path, m.file_length, m.media_type, m.mimetype, c.push_name FROM messages m LEFT JOIN contacts c ON c.session_id = m.session_id AND c.jid = m.sender_jid WHERE m.session_id = ? AND m.chat_jid = ? ORDER BY m.msg_timestamp DESC, m.id DESC LIMIT ? OFFSET ?";
+            let rows: Vec<mysql_async::Row> = conn
+                .exec(sql, (session_id, chat_jid, limit, offset))
+                .await?;
+            Ok(rows.iter().map(my_row_to_chat_message).collect())
+        }
+        DbPool::SQLite(handle) => {
+            let sql = "SELECT m.id, m.message_id, m.session_id, m.chat_jid, m.sender_jid, m.direction, m.msg_type, m.body, m.msg_timestamp, m.media_key, m.file_sha256, m.file_enc_sha256, m.direct_path, m.file_length, m.media_type, m.mimetype, c.push_name FROM messages m LEFT JOIN contacts c ON c.session_id = m.session_id AND c.jid = m.sender_jid WHERE m.session_id = ? AND m.chat_jid = ? ORDER BY m.msg_timestamp DESC, m.id DESC LIMIT ? OFFSET ?";
+            let values = vec![
+                SQ::Text(session_id),
+                SQ::Text(chat_jid),
+                SQ::Int(limit),
+                SQ::Int(offset),
+            ];
+            sqlite_blocking(handle, move |conn| {
+                sqlite_raw::query(conn, sql, &values, sqlite_row_to_chat_message)
+            })
+            .await
+        }
+    }
+}
+
 /// Postgres ILIKE fallback, broken out because the primary path borrows
 /// the pooled client already.
 async fn pg_search_ilike(
@@ -388,6 +515,36 @@ fn pg_row_to_message(row: &tokio_postgres::Row) -> MessageRow {
         body: row.get("body"),
         msg_timestamp: fmt_utc(row.get::<_, chrono::DateTime<chrono::Utc>>("msg_timestamp")),
         snippet: row.get("snippet"),
+        media: None,
+        push_name: None,
+    }
+}
+
+fn pg_row_to_chat_message(row: &tokio_postgres::Row) -> MessageRow {
+    let media = row
+        .get::<_, Option<String>>("media_key")
+        .map(|media_key| MediaPointer {
+            media_key,
+            file_sha256: row.get("file_sha256"),
+            file_enc_sha256: row.get("file_enc_sha256"),
+            direct_path: row.get("direct_path"),
+            file_length: row.get::<_, Option<i64>>("file_length").unwrap_or(0),
+            media_type: row.get("media_type"),
+            mimetype: row.get("mimetype"),
+        });
+    MessageRow {
+        id: row.get("id"),
+        message_id: row.get("message_id"),
+        session_id: row.get("session_id"),
+        chat_jid: row.get("chat_jid"),
+        sender_jid: row.get("sender_jid"),
+        direction: row.get("direction"),
+        msg_type: row.get("msg_type"),
+        body: row.get("body"),
+        msg_timestamp: fmt_utc(row.get::<_, chrono::DateTime<chrono::Utc>>("msg_timestamp")),
+        snippet: None,
+        media,
+        push_name: row.get("push_name"),
     }
 }
 
@@ -402,14 +559,16 @@ fn my_get_string(row: &mysql_async::Row, col: &str) -> Option<String> {
 }
 
 fn my_get_i64(row: &mysql_async::Row, col: &str) -> i64 {
+    my_get_opt_i64(row, col).unwrap_or(0)
+}
+
+fn my_get_opt_i64(row: &mysql_async::Row, col: &str) -> Option<i64> {
     use mysql_async::Value;
-    let Some(idx) = row.columns_ref().iter().position(|c| c.name_str() == col) else {
-        return 0;
-    };
-    match row.as_ref(idx) {
-        Some(Value::Int(i)) => *i,
-        Some(Value::UInt(u)) => *u as i64,
-        _ => 0,
+    let idx = row.columns_ref().iter().position(|c| c.name_str() == col)?;
+    match row.as_ref(idx)? {
+        Value::Int(i) => Some(*i),
+        Value::UInt(u) => Some(*u as i64),
+        _ => None,
     }
 }
 
@@ -425,6 +584,34 @@ fn my_row_to_message(row: &mysql_async::Row) -> MessageRow {
         body: my_get_string(row, "body"),
         msg_timestamp: my_get_string(row, "msg_timestamp").unwrap_or_default(),
         snippet: my_get_string(row, "snippet"),
+        media: None,
+        push_name: None,
+    }
+}
+
+fn my_row_to_chat_message(row: &mysql_async::Row) -> MessageRow {
+    let media = my_get_string(row, "media_key").map(|media_key| MediaPointer {
+        media_key,
+        file_sha256: my_get_string(row, "file_sha256").unwrap_or_default(),
+        file_enc_sha256: my_get_string(row, "file_enc_sha256").unwrap_or_default(),
+        direct_path: my_get_string(row, "direct_path").unwrap_or_default(),
+        file_length: my_get_opt_i64(row, "file_length").unwrap_or(0),
+        media_type: my_get_string(row, "media_type").unwrap_or_default(),
+        mimetype: my_get_string(row, "mimetype").unwrap_or_default(),
+    });
+    MessageRow {
+        id: my_get_i64(row, "id"),
+        message_id: my_get_string(row, "message_id").unwrap_or_default(),
+        session_id: my_get_string(row, "session_id").unwrap_or_default(),
+        chat_jid: my_get_string(row, "chat_jid").unwrap_or_default(),
+        sender_jid: my_get_string(row, "sender_jid").unwrap_or_default(),
+        direction: my_get_string(row, "direction").unwrap_or_default(),
+        msg_type: my_get_string(row, "msg_type").unwrap_or_default(),
+        body: my_get_string(row, "body"),
+        msg_timestamp: my_get_string(row, "msg_timestamp").unwrap_or_default(),
+        snippet: None,
+        media,
+        push_name: my_get_string(row, "push_name"),
     }
 }
 
@@ -440,5 +627,36 @@ fn sqlite_row_to_message(row: &sqlite_raw::Row) -> MessageRow {
         body: row.get_string(7),
         msg_timestamp: row.get_string(8).unwrap_or_default(),
         snippet: row.get_string(9),
+        media: None,
+        push_name: None,
+    }
+}
+
+/// Row shape for [`list_by_chat`]: the plain message columns (0-8),
+/// the seven media pointer columns (9-15), then `push_name` from the
+/// `contacts` join (16).
+fn sqlite_row_to_chat_message(row: &sqlite_raw::Row) -> MessageRow {
+    let media = row.get_string(9).map(|media_key| MediaPointer {
+        media_key,
+        file_sha256: row.get_string(10).unwrap_or_default(),
+        file_enc_sha256: row.get_string(11).unwrap_or_default(),
+        direct_path: row.get_string(12).unwrap_or_default(),
+        file_length: row.get_int(13),
+        media_type: row.get_string(14).unwrap_or_default(),
+        mimetype: row.get_string(15).unwrap_or_default(),
+    });
+    MessageRow {
+        id: row.get_int(0),
+        message_id: row.get_string(1).unwrap_or_default(),
+        session_id: row.get_string(2).unwrap_or_default(),
+        chat_jid: row.get_string(3).unwrap_or_default(),
+        sender_jid: row.get_string(4).unwrap_or_default(),
+        direction: row.get_string(5).unwrap_or_default(),
+        msg_type: row.get_string(6).unwrap_or_default(),
+        body: row.get_string(7),
+        msg_timestamp: row.get_string(8).unwrap_or_default(),
+        snippet: None,
+        media,
+        push_name: row.get_string(16),
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -8,6 +8,12 @@ pub async fn init_schema(pool: &DbPool) -> anyhow::Result<()> {
     }
 }
 
+/// `CREATE TABLE IF NOT EXISTS` is a no-op on a table that already
+/// exists, so columns added to `messages` after a DB was first
+/// created (the media pointer + push-name join fields) need an
+/// explicit `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` per column,
+/// each run independently so an already-present column never aborts
+/// the rest. Mirrors the tolerant migration list [`init_mysql`] runs.
 async fn init_sqlite(pool: &crate::db::session::SqlitePool) -> anyhow::Result<()> {
     use crate::db::sqlite_raw;
     sqlite_blocking(pool, |conn| {
@@ -125,6 +131,13 @@ async fn init_sqlite(pool: &crate::db::session::SqlitePool) -> anyhow::Result<()
                 body TEXT, \
                 msg_timestamp TEXT NOT NULL, \
                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%S','now')), \
+                media_key TEXT, \
+                file_sha256 TEXT, \
+                file_enc_sha256 TEXT, \
+                direct_path TEXT, \
+                file_length INTEGER, \
+                media_type TEXT, \
+                mimetype TEXT, \
                 UNIQUE (session_id, message_id) \
              ); \
              CREATE INDEX IF NOT EXISTS idx_messages_session_ts ON messages(session_id, msg_timestamp); \
@@ -145,6 +158,17 @@ async fn init_sqlite(pool: &crate::db::session::SqlitePool) -> anyhow::Result<()
              ); \
              CREATE INDEX IF NOT EXISTS idx_token_sessions_session ON token_sessions(session_id);",
         )?;
+        for sql in [
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS media_key TEXT",
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_sha256 TEXT",
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_enc_sha256 TEXT",
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS direct_path TEXT",
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_length INTEGER",
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS media_type TEXT",
+            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS mimetype TEXT",
+        ] {
+            let _ = sqlite_raw::exec_batch(conn, sql);
+        }
         if let Err(e) = sqlite_raw::exec_batch(
             conn,
             "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(body, session_id UNINDEXED, message_id UNINDEXED);",
@@ -396,6 +420,17 @@ async fn init_postgres(pool: &deadpool_postgres::Pool) -> anyhow::Result<()> {
             &[],
         )
         .await?;
+    for sql in [
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS media_key TEXT",
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_sha256 TEXT",
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_enc_sha256 TEXT",
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS direct_path TEXT",
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_length BIGINT",
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS media_type TEXT",
+        "ALTER TABLE messages ADD COLUMN IF NOT EXISTS mimetype TEXT",
+    ] {
+        let _ = client.execute(sql, &[]).await;
+    }
     client
         .execute(
             "CREATE INDEX IF NOT EXISTS idx_messages_session_ts ON messages(session_id, msg_timestamp)",
@@ -610,6 +645,13 @@ async fn init_mysql(pool: &mysql_async::Pool) -> anyhow::Result<()> {
             body TEXT NULL,
             msg_timestamp VARCHAR(30) NOT NULL,
             created_at VARCHAR(30) NOT NULL DEFAULT '1970-01-01 00:00:00',
+            media_key TEXT NULL,
+            file_sha256 TEXT NULL,
+            file_enc_sha256 TEXT NULL,
+            direct_path TEXT NULL,
+            file_length BIGINT NULL,
+            media_type VARCHAR(16) NULL,
+            mimetype VARCHAR(255) NULL,
             UNIQUE KEY uniq_messages_id (session_id, message_id),
             INDEX idx_messages_session_ts (session_id, msg_timestamp),
             INDEX idx_messages_chat (session_id, chat_jid),
@@ -664,6 +706,13 @@ async fn init_mysql(pool: &mysql_async::Pool) -> anyhow::Result<()> {
         "ALTER TABLE contacts MODIFY COLUMN push_name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL",
         "ALTER TABLE contacts MODIFY COLUMN business_name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL",
         "ALTER TABLE contacts MODIFY COLUMN source VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'unknown'",
+        "ALTER TABLE messages ADD COLUMN media_key TEXT NULL",
+        "ALTER TABLE messages ADD COLUMN file_sha256 TEXT NULL",
+        "ALTER TABLE messages ADD COLUMN file_enc_sha256 TEXT NULL",
+        "ALTER TABLE messages ADD COLUMN direct_path TEXT NULL",
+        "ALTER TABLE messages ADD COLUMN file_length BIGINT NULL",
+        "ALTER TABLE messages ADD COLUMN media_type VARCHAR(16) NULL",
+        "ALTER TABLE messages ADD COLUMN mimetype VARCHAR(255) NULL",
     ];
     for sql in &migrations {
         let _ = conn.query_drop(*sql).await;

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -27,10 +27,12 @@ use axum::{
 };
 use wacore_binary::jid::Jid;
 
-use crate::db::messages::{self, MessageRow, NewMessage};
+use crate::db::messages::{self, MediaPointer, MessageRow, NewMessage};
 use crate::error::ApiError;
+use crate::models::media::MediaType;
 use crate::models::search::{
-    MessageFleetSearchQuery, MessageHit, MessageSearchQuery, MessageSearchResponse,
+    ChatMessagesQuery, MessageFleetSearchQuery, MessageHit, MessageMedia, MessageSearchQuery,
+    MessageSearchResponse,
 };
 use crate::state::AppState;
 
@@ -74,6 +76,7 @@ pub(crate) async fn record_incoming(
         msg_type,
         body: text.or(caption),
         msg_timestamp: info.timestamp,
+        media: crate::handlers::sessions::extract_media_pointer(msg),
     };
     if let Err(e) = messages::insert(state.session_manager().pool(), &row).await {
         tracing::warn!("message history insert (incoming) failed: {}", e);
@@ -103,6 +106,7 @@ pub(crate) async fn record_outgoing(
         msg_type,
         body: text.or(caption),
         msg_timestamp: chrono::Utc::now(),
+        media: crate::handlers::sessions::extract_media_pointer(message),
     };
     if let Err(e) = messages::insert(state.session_manager().pool(), &row).await {
         tracing::warn!("message history insert (outgoing) failed: {}", e);
@@ -185,6 +189,63 @@ pub async fn search_all_messages(
     Ok(Json(rows_to_response(rows)))
 }
 
+#[utoipa::path(
+    get,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/messages/chat/{chat_jid}",
+    tag = "messages",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("chat_jid" = String, Path, description = "Chat JID (DM partner or group JID)"),
+        ChatMessagesQuery,
+    ),
+    responses(
+        (status = 200, description = "This chat's history, newest first, with sender push_name and any media download pointer", body = MessageSearchResponse),
+        (status = 404, description = "Session not found")
+    )
+)]
+pub async fn list_chat_messages(
+    State(state): State<AppState>,
+    Path((session_id, chat_jid)): Path<(String, String)>,
+    Query(q): Query<ChatMessagesQuery>,
+) -> Result<Json<MessageSearchResponse>, ApiError> {
+    if state.get_session(&session_id).is_none() {
+        return Err(ApiError::SessionNotFound(session_id));
+    }
+    let limit = q.limit.unwrap_or(20).clamp(1, 200);
+    let offset = q.offset.unwrap_or(0).max(0);
+    let rows = messages::list_by_chat(
+        state.session_manager().pool(),
+        &session_id,
+        &chat_jid,
+        limit,
+        offset,
+    )
+    .await
+    .map_err(|e| ApiError::Internal(e.to_string()))?;
+    Ok(Json(rows_to_response(rows)))
+}
+
+fn media_pointer_to_model(m: &MediaPointer) -> Option<MessageMedia> {
+    let media_type = match m.media_type.as_str() {
+        "image" => MediaType::Image,
+        "video" => MediaType::Video,
+        "audio" => MediaType::Audio,
+        "document" => MediaType::Document,
+        "sticker" => MediaType::Sticker,
+        _ => return None,
+    };
+    Some(MessageMedia {
+        direct_path: m.direct_path.clone(),
+        media_key: m.media_key.clone(),
+        file_sha256: m.file_sha256.clone(),
+        file_enc_sha256: m.file_enc_sha256.clone(),
+        file_length: m.file_length.max(0) as u64,
+        media_type,
+        mimetype: m.mimetype.clone(),
+    })
+}
+
 fn rows_to_response(rows: Vec<MessageRow>) -> MessageSearchResponse {
     let messages: Vec<MessageHit> = rows
         .iter()
@@ -199,6 +260,8 @@ fn rows_to_response(rows: Vec<MessageRow>) -> MessageSearchResponse {
             body: r.body.clone(),
             snippet: r.snippet.clone(),
             msg_timestamp: r.msg_timestamp.clone(),
+            push_name: r.push_name.clone(),
+            media: r.media.as_ref().and_then(media_pointer_to_model),
         })
         .collect();
     MessageSearchResponse {

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -1553,6 +1553,54 @@ fn extract_media_metadata(msg: &waproto::whatsapp::Message) -> serde_json::Value
     serde_json::Value::Null
 }
 
+/// Typed counterpart to [`extract_media_metadata`] for message-history
+/// persistence ([`crate::handlers::search::record_incoming`] /
+/// `record_outgoing`): the same five media envelopes, but shaped as
+/// [`crate::db::messages::MediaPointer`] instead of a webhook JSON blob,
+/// and `None` when the message isn't media or is missing a field
+/// `/media/download` requires (an incomplete pointer is useless, so a
+/// message with one is stored with no media pointer at all rather than
+/// a partially-filled one).
+pub(crate) fn extract_media_pointer(
+    msg: &waproto::whatsapp::Message,
+) -> Option<crate::db::messages::MediaPointer> {
+    use base64::Engine as _;
+    fn b64(b: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(b)
+    }
+
+    macro_rules! pointer {
+        ($m:expr, $kind:literal) => {
+            Some(crate::db::messages::MediaPointer {
+                media_key: b64($m.media_key.as_ref()?),
+                file_sha256: b64($m.file_sha256.as_ref()?),
+                file_enc_sha256: b64($m.file_enc_sha256.as_ref()?),
+                direct_path: $m.direct_path.clone()?,
+                file_length: $m.file_length? as i64,
+                media_type: $kind.to_string(),
+                mimetype: $m.mimetype.clone().unwrap_or_default(),
+            })
+        };
+    }
+
+    if let Some(im) = msg.image_message.as_option() {
+        return pointer!(im, "image");
+    }
+    if let Some(vm) = msg.video_message.as_option() {
+        return pointer!(vm, "video");
+    }
+    if let Some(am) = msg.audio_message.as_option() {
+        return pointer!(am, "audio");
+    }
+    if let Some(dm) = msg.document_message.as_option() {
+        return pointer!(dm, "document");
+    }
+    if let Some(sm) = msg.sticker_message.as_option() {
+        return pointer!(sm, "sticker");
+    }
+    None
+}
+
 /// Extracts location data (lat/lng + optional name/address/url) from a
 /// LocationMessage / LiveLocationMessage when present. Returns null otherwise.
 fn extract_location(msg: &waproto::whatsapp::Message) -> serde_json::Value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,6 +242,7 @@ use state::AppState;
 
         handlers::search::search_session_messages,
         handlers::search::search_all_messages,
+        handlers::search::list_chat_messages,
 
         handlers::tokens::mint_token,
         handlers::tokens::list_tokens,
@@ -415,6 +416,7 @@ use state::AppState;
             models::blast::BlastRecipientListResponse,
 
             models::search::MessageHit,
+            models::search::MessageMedia,
             models::search::MessageSearchResponse,
 
             models::common::SuccessResponse,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -10,6 +10,23 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use crate::models::media::MediaType;
+
+/// Download pointer for a media message, shaped to be passed straight
+/// into `POST /sessions/{session_id}/media/download` as-is (same field
+/// names and encodings as
+/// [`crate::models::media::DownloadMediaRequest`]).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct MessageMedia {
+    pub direct_path: String,
+    pub media_key: String,
+    pub file_sha256: String,
+    pub file_enc_sha256: String,
+    pub file_length: u64,
+    pub media_type: MediaType,
+    pub mimetype: String,
+}
+
 /// One message matched by search, newest first.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct MessageHit {
@@ -54,6 +71,17 @@ pub struct MessageHit {
     /// Message time as `%Y-%m-%d %H:%M:%S` UTC text.
     #[schema(example = "2026-07-21 10:30:00")]
     pub msg_timestamp: String,
+
+    /// Sender's WhatsApp display name, from the `contacts` table.
+    /// Only populated by `GET /messages/chat/{chat_jid}` — always
+    /// `null` from `/messages/search`.
+    #[schema(example = "Jane Doe")]
+    pub push_name: Option<String>,
+
+    /// Download pointer, present when `msg_type` is a media type.
+    /// Only populated by `GET /messages/chat/{chat_jid}` — always
+    /// `null` from `/messages/search`.
+    pub media: Option<MessageMedia>,
 }
 
 /// Search result page.
@@ -73,6 +101,16 @@ pub struct MessageSearchQuery {
     /// via the backend's full-text index (LIKE fallback).
     pub q: String,
 
+    /// Page size (default 20, max 200).
+    pub limit: Option<i64>,
+
+    /// Rows to skip (default 0).
+    pub offset: Option<i64>,
+}
+
+/// Query params for `GET /api/v1/sessions/{session_id}/messages/chat/{chat_jid}`.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct ChatMessagesQuery {
     /// Page size (default 20, max 200).
     pub limit: Option<i64>,
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -270,6 +270,10 @@ fn session_routes() -> Router<AppState> {
             get(handlers::search::search_session_messages),
         )
         .route(
+            "/{session_id}/messages/chat/{chat_jid}",
+            get(handlers::search::list_chat_messages),
+        )
+        .route(
             "/{session_id}/messages/newsletter-forward",
             post(handlers::messages::send_newsletter_forward),
         )

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -12,7 +12,8 @@ use chrono::{Duration, Utc};
 use common::{call, req_get, req_json, Harness, TEST_TOKEN};
 use serde_json::json;
 
-use waxum::db::messages::{insert, NewMessage};
+use waxum::db::contacts::{ContactStore, ContactUpsert};
+use waxum::db::messages::{insert, MediaPointer, NewMessage};
 
 async fn seed_session(h: &Harness, id: &str) {
     let (status, _) = call(
@@ -49,6 +50,7 @@ fn msg(
         msg_type: msg_type.to_string(),
         body: body.map(str::to_string),
         msg_timestamp: ts,
+        media: None,
     }
 }
 
@@ -362,6 +364,71 @@ async fn special_match_syntax_in_query_does_not_error() {
         .await;
         assert_eq!(status, StatusCode::OK, "query {q} should not error");
     }
+}
+
+#[tokio::test]
+async fn chat_listing_includes_push_name_and_media_pointer() {
+    let h = Harness::new().await;
+    seed_session(&h, "search-s-08").await;
+
+    ContactStore::new(&h.pool)
+        .upsert(&ContactUpsert {
+            session_id: "search-s-08",
+            jid: "559999999999@s.whatsapp.net",
+            push_name: Some("Jane Doe"),
+            source: "message",
+            ..Default::default()
+        })
+        .await
+        .expect("contact upsert");
+
+    let mut text_row = msg(
+        "MID-C1",
+        "search-s-08",
+        "in",
+        "text",
+        Some("hey there"),
+        ts(2),
+    );
+    text_row.chat_jid = "120000000000000000@g.us".to_string();
+    insert(&h.pool, &text_row).await.expect("insert");
+
+    let mut image_row = msg("MID-C2", "search-s-08", "in", "image", None, ts(1));
+    image_row.chat_jid = "120000000000000000@g.us".to_string();
+    image_row.media = Some(MediaPointer {
+        media_key: "a2V5".to_string(),
+        file_sha256: "c2hh".to_string(),
+        file_enc_sha256: "ZW5j".to_string(),
+        direct_path: "/v/t/abc".to_string(),
+        file_length: 1234,
+        media_type: "image".to_string(),
+        mimetype: "image/jpeg".to_string(),
+    });
+    insert(&h.pool, &image_row).await.expect("insert");
+
+    let (status, body) = call(
+        &h.app,
+        req_get(
+            "/api/v1/sessions/search-s-08/messages/chat/120000000000000000@g.us",
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"], 2);
+    let hits = body["messages"].as_array().expect("messages array");
+
+    assert_eq!(hits[0]["message_id"], "MID-C2");
+    assert_eq!(hits[0]["push_name"], "Jane Doe");
+    assert_eq!(hits[0]["media"]["media_key"], "a2V5");
+    assert_eq!(hits[0]["media"]["file_sha256"], "c2hh");
+    assert_eq!(hits[0]["media"]["direct_path"], "/v/t/abc");
+    assert_eq!(hits[0]["media"]["file_length"], 1234);
+    assert_eq!(hits[0]["media"]["media_type"], "image");
+
+    assert_eq!(hits[1]["message_id"], "MID-C1");
+    assert_eq!(hits[1]["push_name"], "Jane Doe");
+    assert_eq!(hits[1]["media"], serde_json::Value::Null);
 }
 
 fn urlencoding(s: &str) -> String {


### PR DESCRIPTION
## Summary
- New `GET /sessions/{id}/messages/chat/{chat_jid}`: lists a chat's history newest-first, paginated, **no search term required** — the previous `/messages/search` endpoint only supported free-text search across a whole session with no per-chat filter, so there was no way to just "show me this chat".
- Each row now includes the sender's `push_name` (joined from `contacts`) and, for media messages, a `media` download pointer shaped to pass straight into `POST /media/download` with no re-encoding.
- The `messages` table gained 7 columns (`media_key`, `file_sha256`, `file_enc_sha256`, `direct_path`, `file_length`, `media_type`, `mimetype`) so a media message's download parameters survive past the original event — previously nothing about a received image/video/audio/document/sticker was persisted for later download once the live handler moved on.
- Migrated across all three backends (SQLite 3.35+ `ADD COLUMN IF NOT EXISTS`, Postgres, MySQL), tolerant of already-migrated databases, following the existing house pattern for additive schema changes.
- `/messages/search` is unchanged — its rows still carry `push_name: null` / `media: null`; only the new chat-listing endpoint populates them.
- waxum `0.11.4` -> `0.11.5`.

Built to back a WhatsApp MCP server's `get_messages`/`download_media` tools.

## Test plan
- [x] `cargo build -j 4` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -j 4` — all suites pass, including a new `chat_listing_includes_push_name_and_media_pointer` test in `tests/search.rs` covering the push_name join and media pointer round-trip
- [ ] Not verified against a live WhatsApp connection (sandboxed environment)