### PR TITLE
v0.11.6 — bump vendored whatsapp-rust to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.11.6] - 2026-08-07
+
+### Changed
+
+Bumped the vendored `whatsapp-rust` (and `wacore`/`waproto`/etc.) git
+rev to `f8165f28` (upstream `0.7.0`) — 11 commits: binary-wire decode
+perf work (packed-value unpacking, node fan-out allocations, wire-path
+validation reuse), two new opt-in libsignal hooks (prewarming the
+sender-key derivation memo, supplying a custom X25519 agreement), plus
+tests/benches/docs. No API break, no waxum source changes required —
+`cargo build`/`clippy`/`test` all pass unmodified against the bump.
+
 ## [0.11.5] - 2026-08-06
 
 ### Added — `GET /sessions/{id}/messages/chat/{chat_jid}`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2008,7 +2008,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3206,7 +3206,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -3244,7 +3244,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4966,8 +4966,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wacore"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.0",
@@ -5016,8 +5016,8 @@ dependencies = [
 
 [[package]]
 name = "wacore-appstate"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5037,8 +5037,8 @@ dependencies = [
 
 [[package]]
 name = "wacore-binary"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "bytes",
  "compact_str",
@@ -5054,8 +5054,8 @@ dependencies = [
 
 [[package]]
 name = "wacore-derive"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5064,8 +5064,8 @@ dependencies = [
 
 [[package]]
 name = "wacore-libsignal"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "aes 0.9.2",
  "async-lock",
@@ -5095,8 +5095,8 @@ dependencies = [
 
 [[package]]
 name = "wacore-noise"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5132,8 +5132,8 @@ dependencies = [
 
 [[package]]
 name = "waproto"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5462,8 +5462,8 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5507,8 +5507,8 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-sqlite-storage"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "async-trait",
  "buffa",
@@ -5527,8 +5527,8 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-tokio-transport"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5547,8 +5547,8 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
-version = "0.6.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=2b60761868042b4942188f975be21da8d1e95fd3#2b60761868042b4942188f975be21da8d1e95fd3"
+version = "0.7.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=f8165f282008935732e0b26d6f5cca5038ecd222#f8165f282008935732e0b26d6f5cca5038ecd222"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"
@@ -10,13 +10,13 @@ repository = "https://github.com/imtaqin/waxum"
 [dependencies]
 
 rand = "0.8"
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3", default-features = true, features = ["voip", "tracing"] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
-whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "2b60761868042b4942188f975be21da8d1e95fd3" }
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222", default-features = true, features = ["voip", "tracing"] }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222" }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222" }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222" }
+whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222" }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "f8165f282008935732e0b26d6f5cca5038ecd222" }
 
 # Web framework
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }


### PR DESCRIPTION
## Summary
- Bump the vendored `whatsapp-rust`/`wacore`/`waproto`/etc. git rev from `2b60761868` to `f8165f282008` (upstream `0.7.0`).
- 11 upstream commits: binary-wire decode perf work (packed-value unpacking, node fan-out allocations, wire-path validator reuse), two new opt-in libsignal hooks (prewarm sender-key derivation memo, custom X25519 agreement), plus tests/benches/docs.
- No API break — waxum source unchanged, `Cargo.toml`/`Cargo.lock` only.
- `waxum` version bumped 0.11.5 → 0.11.6.

## Test plan
- [x] `cargo build -j 4`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -j 4 -- -D warnings`
- [x] `cargo test -j 4` (full suite)
- [x] pre-push hook passed clean on `git push`