### PR TITLE
feat: resolve open issues #66–#73 (sessions, webhooks, messages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [Unreleased]
+
+### BREAKING — webhook signature scheme is now versioned (`v2`)
+
+Every webhook delivery now carries an `X-Webhook-Signature-Version: v2`
+header so consumers can detect which HMAC scheme produced
+`X-Webhook-Signature`. `v2` is the timestamp-prefixed scheme introduced
+in v0.9.8 — HMAC-SHA256 over `"{timestamp}.{body}"` (the
+`X-Webhook-Timestamp` value and the raw request body joined with a
+literal `.`), hex-encoded digest with a `sha256=` prefix. The pre-0.9.8
+scheme (HMAC over the raw body alone) carried no version header;
+consumers that support both should treat a missing header as `v1`. No
+change to the `v2` signing algorithm itself — deliveries are signed
+exactly as before, the header only makes the scheme explicit.
+
+### Added — webhook delivery retries with backoff + dead-letter queue
+
+Failed webhook deliveries (non-2xx or transport error) are no longer
+dropped after the first round of attempts:
+
+- **Configurable retry policy.** `WEBHOOK_RETRY_MAX_ATTEMPTS`
+  (default `3`) sets total attempts per event with exponential backoff
+  (immediate, +5 s, +30 s, then doubling capped at 5 min).
+  `WEBHOOK_RETRY_ON_4XX` (default `true`) also retries 4xx responses —
+  a 401/403 window is usually a fixable consumer-side misconfig, and
+  dropping those events loses messages; set it to `false` to restore
+  the old "4xx is permanent" behavior (408/429 are retried either way).
+  Retries run in a spawned task and still respect the per-URL circuit
+  breaker.
+- **Dead-letter queue.** Deliveries that exhaust every attempt are
+  parked in a bounded per-session in-memory DLQ (`WEBHOOK_DLQ_CAPACITY`,
+  default `100`, oldest evicted past the cap) in addition to the
+  existing DB `webhook_dlq` table. Each entry keeps everything needed
+  to replay: session id, webhook URL, event name, verbatim payload,
+  captured HMAC secret, failure reason, attempt count and timestamp.
+  Note: the in-memory queue is **lost on restart** — the DB table is
+  the durable record.
+- **New endpoints** to inspect and replay the DLQ:
+  - `GET /api/v1/sessions/{session_id}/webhooks/dlq` — list entries,
+    newest first.
+  - `POST /api/v1/sessions/{session_id}/webhooks/dlq/{entry_id}/replay` —
+    re-deliver the stored payload through the same signing/retry path;
+    a failed replay lands back in the DLQ as a new entry.
+
 ## [0.11.6] - 2026-08-07
 
 ### Changed

--- a/src/console/handlers.rs
+++ b/src/console/handlers.rs
@@ -463,6 +463,7 @@ pub async fn create_session_proxy(
     let create_req = CreateSessionRequest {
         id: req.id,
         name: req.name,
+        reuse: None,
         webhook: None,
         device: None,
     };

--- a/src/handlers/messages.rs
+++ b/src/handlers/messages.rs
@@ -60,7 +60,36 @@ pub async fn execute_text(
     let client = get_client(state, session_id)?;
     let to_jid = resolve_recipient_jid(client.clone(), parse_jid(&request.to)?).await;
 
-    let context_info: MessageField<waproto::whatsapp::ContextInfo> =
+    let mut mentioned: Vec<String> = Vec::new();
+    if let Some(mentions) = request.mentions {
+        for entry in mentions {
+            let s = parse_jid(&entry)?.to_string();
+            if !mentioned.contains(&s) {
+                mentioned.push(s);
+            }
+        }
+    }
+    let explicit_mentions = mentioned.len();
+    if request.mention_all.unwrap_or(false) {
+        if to_jid.server != wacore_binary::jid::GROUP_SERVER {
+            return Err(ApiError::BadRequest(
+                "mention_all is only supported for group chats".to_string(),
+            ));
+        }
+        let metadata = client
+            .groups()
+            .get_metadata(&to_jid)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        for p in metadata.participants {
+            let s = p.jid.to_string();
+            if !mentioned.contains(&s) {
+                mentioned.push(s);
+            }
+        }
+    }
+
+    let mut context_info: MessageField<waproto::whatsapp::ContextInfo> =
         if let Some(ref fake) = request.fake_reply {
             crate::handlers::fake_reply::build_fake_reply_context_info(fake).into()
         } else {
@@ -73,10 +102,24 @@ pub async fn execute_text(
                 .into()
         };
 
+    let mut text = request.text;
+    if !mentioned.is_empty() {
+        for jid_str in &mentioned[..explicit_mentions] {
+            let at_form = format!("@{}", jid_str.split('@').next().unwrap_or(jid_str));
+            if !text.contains(&at_form) {
+                if !text.ends_with(' ') {
+                    text.push(' ');
+                }
+                text.push_str(&at_form);
+            }
+        }
+        context_info.get_or_insert_default().mentioned_jid = mentioned;
+    }
+
     let message = waproto::whatsapp::Message {
         extended_text_message: MessageField::some(
             waproto::whatsapp::message::ExtendedTextMessage {
-                text: Some(request.text),
+                text: Some(text),
                 context_info,
                 ..Default::default()
             },
@@ -3294,6 +3337,8 @@ pub async fn send_message(
             text: request.text,
             reply_to: None,
             fake_reply: None,
+            mentions: None,
+            mention_all: None,
             send_at: None,
         }),
     )

--- a/src/handlers/operations.rs
+++ b/src/handlers/operations.rs
@@ -313,8 +313,7 @@ pub async fn tctoken_list(
     request_body = AutoReconnectRequest,
     responses(
         (status = 200, description = "Auto-reconnect updated", body = AutoReconnectResponse),
-        (status = 404, description = "Session not found"),
-        (status = 503, description = "Not connected")
+        (status = 404, description = "Session not found")
     )
 )]
 pub async fn set_auto_reconnect(
@@ -322,13 +321,19 @@ pub async fn set_auto_reconnect(
     Path(session_id): Path<String>,
     Json(request): Json<AutoReconnectRequest>,
 ) -> Result<Json<AutoReconnectResponse>, ApiError> {
-    let client = get_client(&state, &session_id)?;
+    let runtime = config_runtime(&state, &session_id).await?;
 
-    client
-        .enable_auto_reconnect
-        .store(request.enabled, Ordering::Relaxed);
+    runtime.set_auto_reconnect_pref(request.enabled);
 
-    let error_count = client.stats().reconnect_errors;
+    let error_count = match runtime.get_client() {
+        Some(client) => {
+            client
+                .enable_auto_reconnect
+                .store(request.enabled, Ordering::Relaxed);
+            client.stats().reconnect_errors
+        }
+        None => 0,
+    };
 
     Ok(Json(AutoReconnectResponse {
         enabled: request.enabled,
@@ -346,18 +351,20 @@ pub async fn set_auto_reconnect(
     ),
     responses(
         (status = 200, description = "Auto-reconnect status", body = AutoReconnectResponse),
-        (status = 404, description = "Session not found"),
-        (status = 503, description = "Not connected")
+        (status = 404, description = "Session not found")
     )
 )]
 pub async fn get_auto_reconnect(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<Json<AutoReconnectResponse>, ApiError> {
-    let client = get_client(&state, &session_id)?;
+    let runtime = config_runtime(&state, &session_id).await?;
 
-    let enabled = client.enable_auto_reconnect.load(Ordering::Relaxed);
-    let error_count = client.stats().reconnect_errors;
+    let enabled = runtime.auto_reconnect_enabled();
+    let error_count = runtime
+        .get_client()
+        .map(|c| c.stats().reconnect_errors)
+        .unwrap_or(0);
 
     Ok(Json(AutoReconnectResponse {
         enabled,
@@ -378,8 +385,7 @@ pub async fn get_auto_reconnect(
     request_body = HistorySyncRequest,
     responses(
         (status = 200, description = "History sync setting updated", body = HistorySyncResponse),
-        (status = 404, description = "Session not found"),
-        (status = 503, description = "Not connected")
+        (status = 404, description = "Session not found")
     )
 )]
 pub async fn set_history_sync(
@@ -387,12 +393,15 @@ pub async fn set_history_sync(
     Path(session_id): Path<String>,
     Json(request): Json<HistorySyncRequest>,
 ) -> Result<Json<HistorySyncResponse>, ApiError> {
-    let client = get_client(&state, &session_id)?;
+    let runtime = config_runtime(&state, &session_id).await?;
 
-    client.set_skip_history_sync(request.skip);
+    runtime.set_skip_history_sync_pref(request.skip);
+    if let Some(client) = runtime.get_client() {
+        client.set_skip_history_sync(request.skip);
+    }
 
     Ok(Json(HistorySyncResponse {
-        skip_history_sync: client.skip_history_sync_enabled(),
+        skip_history_sync: request.skip,
     }))
 }
 
@@ -406,18 +415,17 @@ pub async fn set_history_sync(
     ),
     responses(
         (status = 200, description = "History sync setting", body = HistorySyncResponse),
-        (status = 404, description = "Session not found"),
-        (status = 503, description = "Not connected")
+        (status = 404, description = "Session not found")
     )
 )]
 pub async fn get_history_sync(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
 ) -> Result<Json<HistorySyncResponse>, ApiError> {
-    let client = get_client(&state, &session_id)?;
+    let runtime = config_runtime(&state, &session_id).await?;
 
     Ok(Json(HistorySyncResponse {
-        skip_history_sync: client.skip_history_sync_enabled(),
+        skip_history_sync: runtime.skip_history_sync(),
     }))
 }
 
@@ -430,4 +438,35 @@ fn get_client(
         .ok_or(ApiError::NotConnected)?;
 
     runtime.get_live_client().ok_or(ApiError::NotConnected)
+}
+
+/// Resolve the session's runtime for per-session config read/write
+/// endpoints, creating the in-memory runtime from the DB row when the
+/// session has no live client in this process. Config must be
+/// serviceable while the socket is down — disabling auto-reconnect on a
+/// dead session is exactly the case that needs it — so unlike
+/// [`get_client`] this never returns 503 for a known session.
+async fn config_runtime(
+    state: &AppState,
+    session_id: &str,
+) -> Result<std::sync::Arc<crate::state::SessionState>, ApiError> {
+    let _ = state
+        .session_manager()
+        .get_session(session_id)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+        .ok_or_else(|| ApiError::SessionNotFound(session_id.to_string()))?;
+
+    if let Some(runtime) = state.get_session(session_id) {
+        return Ok(runtime);
+    }
+
+    let storage_path = state
+        .session_manager()
+        .get_storage_path(session_id)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+        .unwrap_or_else(|| format!("{}/{}", state.base_storage_path(), session_id));
+
+    Ok(state.get_or_create_session(session_id, &storage_path))
 }

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -26,8 +26,9 @@ use crate::state::AppState;
     request_body = CreateSessionRequest,
     responses(
         (status = 201, description = "Session created and connecting", body = CreateSessionResponse),
+        (status = 200, description = "Existing session reused (re-scan started on the same slot)", body = CreateSessionResponse),
         (status = 400, description = "Invalid request"),
-        (status = 409, description = "Session ID already exists")
+        (status = 409, description = "Session ID already exists (set `reuse: true` to re-scan the same slot)")
     )
 )]
 pub async fn create_session(
@@ -36,14 +37,20 @@ pub async fn create_session(
 ) -> Result<Json<CreateSessionResponse>, ApiError> {
     let session_id = request.id.unwrap_or_else(|| Uuid::new_v4().to_string());
 
-    if state
+    if let Some(existing) = state
         .session_manager()
         .get_session(&session_id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
-        .is_some()
     {
-        return Err(ApiError::AlreadyConnected);
+        if !request.reuse.unwrap_or(false) {
+            return Err(ApiError::AlreadyConnected);
+        }
+        let connect_req = request
+            .device
+            .map(|d| Json(ConnectRequest { device: Some(d) }));
+        let _ = connect_session(State(state), Path(session_id), connect_req).await?;
+        return Ok(Json(CreateSessionResponse { session: existing }));
     }
 
     let storage_path = format!("{}/{}", state.base_storage_path(), session_id);
@@ -261,37 +268,41 @@ pub async fn get_session_status(
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
 
-    let (status, is_logged_in, pair) = if let Some(runtime) = state.get_session(&session_id) {
-        let ps = runtime.get_pair_state();
-        let pair = crate::models::sessions::PairStatus {
-            last_qr_at: ps.last_qr_at,
-            last_pair_code_at: ps.last_pair_code_at,
-            pair_code_expires_at: ps.pair_code_expires_at,
-            last_error: ps.last_error,
-            attempts: ps.attempts,
-        };
-        if runtime.is_alive() {
-            (SessionStatus::LoggedIn, true, pair)
-        } else {
-            let s = runtime.get_status();
-            let (status, is_logged_in) = if s == SessionStatus::LoggedIn {
-                (SessionStatus::Connecting, true)
-            } else {
-                (s, false)
+    let (status, is_logged_in, socket_alive, pair) =
+        if let Some(runtime) = state.get_session(&session_id) {
+            let ps = runtime.get_pair_state();
+            let pair = crate::models::sessions::PairStatus {
+                last_qr_at: ps.last_qr_at,
+                last_pair_code_at: ps.last_pair_code_at,
+                pair_code_expires_at: ps.pair_code_expires_at,
+                last_error: ps.last_error,
+                attempts: ps.attempts,
             };
-            (status, is_logged_in, pair)
-        }
-    } else {
-        (
-            session.status,
-            session.is_logged_in,
-            crate::models::sessions::PairStatus::default(),
-        )
-    };
+            let socket_alive = runtime.socket_alive();
+            if runtime.is_alive() {
+                (SessionStatus::LoggedIn, true, socket_alive, pair)
+            } else {
+                let s = runtime.get_status();
+                let (status, is_logged_in) = if s == SessionStatus::LoggedIn {
+                    (SessionStatus::Connecting, true)
+                } else {
+                    (s, false)
+                };
+                (status, is_logged_in, socket_alive, pair)
+            }
+        } else {
+            (
+                session.status,
+                session.is_logged_in,
+                false,
+                crate::models::sessions::PairStatus::default(),
+            )
+        };
 
     Ok(Json(SessionStatusResponse {
         status,
         is_logged_in,
+        socket_alive,
         phone_number: session.phone_number,
         push_name: session.push_name,
         pair,
@@ -395,6 +406,7 @@ pub async fn connect_session(
         runtime.set_client(None);
         runtime.set_status(SessionStatus::Disconnected);
         runtime.clear_reconnecting();
+        runtime.clear_lock_cooldown();
     }
 
     let storage_path = state
@@ -1003,7 +1015,8 @@ pub async fn reconnect_all_on_startup(state: AppState) {
 /// crate to eventually recover on its own. Also broadcasts a synthetic
 /// `disconnected` webhook/event as a safety net -- see the module docs on
 /// `Event::Disconnected` for why the crate doesn't always dispatch one for
-/// a socket that dies silently.
+/// a socket that dies silently. Sessions paused by an account-lock
+/// cooldown (`ACCOUNT_LOCK_BACKOFF_SECS`) are skipped outright.
 pub async fn run_reconnect_watchdog(state: AppState) {
     let poll_ms: u64 = std::env::var("RECONNECT_WATCHDOG_POLL_MS")
         .ok()
@@ -1031,6 +1044,14 @@ pub async fn run_reconnect_watchdog(state: AppState) {
         ticker.tick().await;
         for (session_id, runtime) in state.session_iter_with_ids() {
             if runtime.get_status() != SessionStatus::Connecting {
+                continue;
+            }
+            if let Some(remaining) = runtime.lock_cooldown_remaining() {
+                tracing::debug!(
+                    session_id = %session_id,
+                    cooldown_remaining_secs = remaining,
+                    "reconnect watchdog: skipping session in account-lock cooldown"
+                );
                 continue;
             }
             let Some(client) = runtime.get_client() else {
@@ -1152,8 +1173,11 @@ async fn connect_client(
 
     if let Some(runtime) = state.get_session(session_id) {
         let c = bot.client();
-        c.enable_auto_reconnect
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        c.enable_auto_reconnect.store(
+            runtime.auto_reconnect_enabled(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        c.set_skip_history_sync(runtime.skip_history_sync());
         runtime.set_client(Some(c));
         runtime.set_status(SessionStatus::WaitingForQr);
     }
@@ -1247,8 +1271,11 @@ async fn connect_client_with_pair_code(
 
     if let Some(runtime) = state.get_session(session_id) {
         let c = bot.client();
-        c.enable_auto_reconnect
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        c.enable_auto_reconnect.store(
+            runtime.auto_reconnect_enabled(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        c.set_skip_history_sync(runtime.skip_history_sync());
         runtime.set_client(Some(c));
     }
 
@@ -1309,6 +1336,9 @@ async fn handle_event(
         }
         Event::Connected(_) => {
             tracing::info!("Session {}: Connected", session_id);
+            if runtime.reconnecting_for_secs().is_some() {
+                crate::metrics::record_session_reconnect(session_id);
+            }
             runtime.set_status(SessionStatus::LoggedIn);
             runtime.set_qr_codes(vec![]);
             runtime.set_pair_code(None);
@@ -1354,13 +1384,23 @@ async fn handle_event(
             }
             runtime.set_status(SessionStatus::Connecting);
             runtime.mark_reconnecting_now();
+            crate::metrics::record_session_drop(session_id);
             let _ = state
                 .session_manager()
                 .update_session_status(session_id, SessionStatus::Connecting, false)
                 .await;
         }
         Event::LoggedOut(logged_out) => {
+            let is_lock = matches!(
+                logged_out.reason,
+                wacore::types::events::ConnectFailureReason::AccountLocked
+            );
             if let Some(client) = runtime.get_client() {
+                if is_lock {
+                    client
+                        .enable_auto_reconnect
+                        .store(false, std::sync::atomic::Ordering::Relaxed);
+                }
                 client.disconnect().await;
             }
             runtime.set_status(SessionStatus::Disconnected);
@@ -1370,6 +1410,37 @@ async fn handle_event(
                 .session_manager()
                 .update_session_status(session_id, SessionStatus::Disconnected, false)
                 .await;
+
+            if is_lock {
+                let (cooldown_secs, cooldown_until) =
+                    runtime.record_lock_cooldown(&state.account_lock_backoff().schedule);
+                tracing::warn!(
+                    session_id = %session_id,
+                    reason = ?logged_out.reason,
+                    cooldown_secs,
+                    "account_locked, cooling down — auto-reconnect paused until manual reconnect"
+                );
+                let payload = serde_json::json!({
+                    "session_id": session_id,
+                    "event": "account_locked",
+                    "timestamp": chrono::Utc::now().timestamp(),
+                    "data": {
+                        "reason": format!("{:?}", logged_out.reason),
+                        "cooldown_secs": cooldown_secs,
+                        "cooldown_until": cooldown_until,
+                    },
+                });
+                if let Ok(payload_str) = serde_json::to_string(&payload) {
+                    state
+                        .broadcast_to_webhooks(session_id, "account_locked", &payload_str)
+                        .await;
+                    state
+                        .publish_to_nats(session_id, "account_locked", &payload_str)
+                        .await;
+                    runtime.broadcast_event(payload_str);
+                }
+                return;
+            }
 
             let should_purge = runtime.record_logout_and_should_purge();
             if !should_purge {
@@ -1417,6 +1488,17 @@ async fn handle_event(
 
     if let Event::Messages(batch) = event.as_ref() {
         let timestamp = chrono::Utc::now().timestamp();
+        let offline = matches!(
+            batch.origin,
+            wacore::types::events::BatchOrigin::OfflineDrain
+        );
+        if offline {
+            tracing::info!(
+                session_id = %session_id,
+                count = batch.messages.len(),
+                "offline sync: replaying messages received while disconnected"
+            );
+        }
         for im in batch.messages.iter() {
             crate::handlers::search::record_incoming(state, session_id, &im.message, &im.info)
                 .await;
@@ -1426,6 +1508,7 @@ async fn handle_event(
                 "session_id": session_id,
                 "event": "message",
                 "timestamp": timestamp,
+                "offline": offline,
                 "data": data,
             });
             if let Ok(payload) = serde_json::to_string(&payload_value) {

--- a/src/handlers/webhooks.rs
+++ b/src/handlers/webhooks.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 use crate::error::ApiError;
 use crate::models::common::SuccessResponse;
 use crate::models::webhooks::{
-    RegisterWebhookRequest, WebhookConfig, WebhookConfigWithId, WebhookListResponse,
+    RegisterWebhookRequest, WebhookConfig, WebhookConfigWithId, WebhookDlqListResponse,
+    WebhookListResponse,
 };
 use crate::state::AppState;
 
@@ -177,4 +178,98 @@ pub async fn reenable_webhook(
     );
 
     Ok(Json(SuccessResponse::with_message("Webhook re-enabled")))
+}
+
+/// List the session's in-memory dead-letter queue: deliveries that
+/// exhausted every retry attempt. Newest first. The queue is bounded
+/// (`WEBHOOK_DLQ_CAPACITY`, default 100 per session) and volatile — it
+/// is lost on restart.
+#[utoipa::path(
+    get,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/webhooks/dlq",
+    tag = "webhooks",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    responses(
+        (status = 200, description = "Dead-lettered webhook deliveries, newest first", body = WebhookDlqListResponse),
+        (status = 404, description = "Session not found")
+    )
+)]
+pub async fn list_webhook_dlq(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<WebhookDlqListResponse>, ApiError> {
+    let _ = state
+        .session_manager()
+        .get_session(&session_id)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+        .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
+
+    let entries = state.webhook_dlq_list(&session_id);
+    let count = entries.len();
+
+    Ok(Json(WebhookDlqListResponse { entries, count }))
+}
+
+/// Replay one DLQ entry: re-delivers the stored payload verbatim through
+/// the same signing and retry path as a fresh event. The entry is
+/// removed up front; if the re-delivery also exhausts its retries it
+/// lands back in the DLQ as a new entry.
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/webhooks/dlq/{entry_id}/replay",
+    tag = "webhooks",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("entry_id" = String, Path, description = "DLQ entry ID")
+    ),
+    responses(
+        (status = 200, description = "Replay scheduled", body = SuccessResponse),
+        (status = 400, description = "Circuit open for this webhook URL"),
+        (status = 404, description = "DLQ entry not found")
+    )
+)]
+pub async fn replay_webhook_dlq_entry(
+    State(state): State<AppState>,
+    Path((session_id, entry_id)): Path<(String, String)>,
+) -> Result<Json<SuccessResponse>, ApiError> {
+    let entry = state
+        .webhook_dlq_take(&session_id, &entry_id)
+        .ok_or_else(|| ApiError::WebhookNotFound(entry_id.clone()))?;
+
+    if !state.webhook_circuit_allows(&entry.webhook_url) {
+        state.webhook_dlq_push(entry.clone());
+        return Err(ApiError::BadRequest(format!(
+            "webhook circuit is OPEN for {} — replay skipped, try again later",
+            entry.webhook_url
+        )));
+    }
+
+    tracing::info!(
+        "Session {}: Replaying webhook DLQ entry {} to {}",
+        session_id,
+        entry_id,
+        entry.webhook_url
+    );
+
+    let state_for_task = state.clone();
+    tokio::spawn(async move {
+        state_for_task
+            .deliver_webhook(
+                &entry.session_id,
+                &entry.event,
+                &entry.webhook_url,
+                entry.secret,
+                &entry.payload,
+            )
+            .await;
+    });
+
+    Ok(Json(SuccessResponse::with_message(
+        "Webhook DLQ entry replay scheduled",
+    )))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,11 @@
 //! - `RECONNECT_MAX_STUCK_SECS` — seconds a session may sit in
 //!   `Connecting` before the watchdog forces a rebuild, regardless of the
 //!   attempt count (default 600).
+//! - `ACCOUNT_LOCK_BACKOFF_SECS` — comma-separated cooldown schedule
+//!   applied when WhatsApp locks an account (`AccountLocked`); each
+//!   repeat lock walks one step further (default `300,900,3600`, i.e.
+//!   5 → 15 → 60 min). A manual `POST /sessions/:id/connect` lifts the
+//!   cooldown.
 //!
 //! ## Storage
 //!
@@ -223,6 +228,8 @@ use state::AppState;
         handlers::webhooks::register_webhook,
         handlers::webhooks::unregister_webhook,
         handlers::webhooks::reenable_webhook,
+        handlers::webhooks::list_webhook_dlq,
+        handlers::webhooks::replay_webhook_dlq_entry,
 
         handlers::nats_handler::nats_status,
         handlers::nats_handler::nats_purge_stream,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,13 +9,22 @@
 //!   memory.
 //! - `waxum_sessions_live` — sessions whose upstream client agrees it's
 //!   connected AND logged in (source of truth for /status).
+//! - `waxum_session_socket_alive{session_id}` — per-session raw socket
+//!   liveness (1/0), distinct from login state: catches the "limbo"
+//!   where a cached `logged_in` outlives a dead socket.
 //! - `waxum_process_threads` — thread count from `/proc/self/status`.
 //! - `waxum_process_open_fds` — FD count from `/proc/self/fd`.
 //! - `waxum_webhook_circuits_open` — webhook target URLs currently in the
 //!   OPEN circuit-breaker state; alert when this is non-zero for long.
+//!
+//! Counters (per-session, labelled by `session_id`):
+//!
+//! - `waxum_session_socket_drops_total` — `Event::Disconnected` seen.
+//! - `waxum_session_reconnects_total` — `Event::Connected` that closed
+//!   an unplanned reconnect window (initial connects don't count).
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
-use prometheus::{Encoder, IntGauge, Registry, TextEncoder};
+use prometheus::{Encoder, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder};
 use std::sync::OnceLock;
 
 use crate::state::AppState;
@@ -26,6 +35,19 @@ static SESSIONS_LIVE: OnceLock<IntGauge> = OnceLock::new();
 static PROCESS_THREADS: OnceLock<IntGauge> = OnceLock::new();
 static PROCESS_OPEN_FDS: OnceLock<IntGauge> = OnceLock::new();
 static WEBHOOK_CIRCUITS_OPEN: OnceLock<IntGauge> = OnceLock::new();
+static SESSION_SOCKET_ALIVE: OnceLock<IntGaugeVec> = OnceLock::new();
+static SESSION_DROPS: OnceLock<IntCounterVec> = OnceLock::new();
+static SESSION_RECONNECTS: OnceLock<IntCounterVec> = OnceLock::new();
+
+/// Session ids we've already exported per-session series for, so the
+/// scrape loop can prune labels for sessions that were deleted —
+/// otherwise their last gauge value would linger forever.
+static SEEN_SESSIONS: OnceLock<parking_lot::Mutex<std::collections::HashSet<String>>> =
+    OnceLock::new();
+
+fn seen_sessions() -> &'static parking_lot::Mutex<std::collections::HashSet<String>> {
+    SEEN_SESSIONS.get_or_init(|| parking_lot::Mutex::new(std::collections::HashSet::new()))
+}
 
 fn registry() -> &'static Registry {
     REGISTRY.get_or_init(|| {
@@ -55,18 +77,66 @@ fn registry() -> &'static Registry {
             "Webhook target URLs currently in open-circuit state (skipped)",
         )
         .unwrap();
+        let session_socket_alive = IntGaugeVec::new(
+            Opts::new(
+                "waxum_session_socket_alive",
+                "Per-session raw socket liveness (1 = transport connected, 0 = down)",
+            ),
+            &["session_id"],
+        )
+        .unwrap();
+        let session_drops = IntCounterVec::new(
+            Opts::new(
+                "waxum_session_socket_drops_total",
+                "Per-session count of socket drops (Event::Disconnected)",
+            ),
+            &["session_id"],
+        )
+        .unwrap();
+        let session_reconnects = IntCounterVec::new(
+            Opts::new(
+                "waxum_session_reconnects_total",
+                "Per-session count of successful reconnects closing an unplanned retry window",
+            ),
+            &["session_id"],
+        )
+        .unwrap();
         r.register(Box::new(sessions_total.clone())).unwrap();
         r.register(Box::new(sessions_live.clone())).unwrap();
         r.register(Box::new(process_threads.clone())).unwrap();
         r.register(Box::new(process_open_fds.clone())).unwrap();
         r.register(Box::new(webhook_circuits_open.clone())).unwrap();
+        r.register(Box::new(session_socket_alive.clone())).unwrap();
+        r.register(Box::new(session_drops.clone())).unwrap();
+        r.register(Box::new(session_reconnects.clone())).unwrap();
         SESSIONS_TOTAL.set(sessions_total).ok();
         SESSIONS_LIVE.set(sessions_live).ok();
         PROCESS_THREADS.set(process_threads).ok();
         PROCESS_OPEN_FDS.set(process_open_fds).ok();
         WEBHOOK_CIRCUITS_OPEN.set(webhook_circuits_open).ok();
+        SESSION_SOCKET_ALIVE.set(session_socket_alive).ok();
+        SESSION_DROPS.set(session_drops).ok();
+        SESSION_RECONNECTS.set(session_reconnects).ok();
         r
     })
+}
+
+/// Bump the per-session socket-drop counter. Called from the
+/// `Event::Disconnected` arm of the session event loop; a no-op before
+/// the first /metrics scrape initialised the registry.
+pub fn record_session_drop(session_id: &str) {
+    if let Some(c) = SESSION_DROPS.get() {
+        c.with_label_values(&[session_id]).inc();
+    }
+}
+
+/// Bump the per-session successful-reconnect counter. Called from the
+/// `Event::Connected` arm when the connect closed an unplanned retry
+/// window, so initial connects don't inflate it.
+pub fn record_session_reconnect(session_id: &str) {
+    if let Some(c) = SESSION_RECONNECTS.get() {
+        c.with_label_values(&[session_id]).inc();
+    }
 }
 
 fn read_proc_threads() -> Option<i64> {
@@ -89,14 +159,34 @@ pub async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse
 
     let mut total = 0i64;
     let mut live = 0i64;
-    for s in state.session_iter() {
+    let socket_alive_vec = SESSION_SOCKET_ALIVE.get().unwrap();
+    let mut current_ids = std::collections::HashSet::new();
+    for (session_id, s) in state.session_iter_with_ids() {
         total += 1;
         if s.is_alive() {
             live += 1;
         }
+        socket_alive_vec
+            .with_label_values(&[session_id.as_str()])
+            .set(if s.socket_alive() { 1 } else { 0 });
+        current_ids.insert(session_id);
     }
     SESSIONS_TOTAL.get().unwrap().set(total);
     SESSIONS_LIVE.get().unwrap().set(live);
+
+    let mut seen = seen_sessions().lock();
+    for stale in seen.difference(&current_ids).cloned().collect::<Vec<_>>() {
+        let _ = socket_alive_vec.remove_label_values(&[stale.as_str()]);
+        if let Some(c) = SESSION_DROPS.get() {
+            let _ = c.remove_label_values(&[stale.as_str()]);
+        }
+        if let Some(c) = SESSION_RECONNECTS.get() {
+            let _ = c.remove_label_values(&[stale.as_str()]);
+        }
+    }
+    *seen = current_ids;
+    drop(seen);
+
     if let Some(t) = read_proc_threads() {
         PROCESS_THREADS.get().unwrap().set(t);
     }

--- a/src/models/messages.rs
+++ b/src/models/messages.rs
@@ -35,6 +35,22 @@ pub struct SendTextRequest {
 
     pub fake_reply: Option<FakeReplyConfig>,
 
+    /// Optional list of JIDs to @mention in the message. Each entry may
+    /// be a full JID (e.g. `559999999999@s.whatsapp.net`) or a bare
+    /// phone number. The JIDs are attached to the outgoing message's
+    /// `context_info.mentioned_jid`, and any mention whose `@user` form
+    /// is missing from `text` is appended so clients render the mention
+    /// highlight.
+    #[serde(default)]
+    #[schema(example = json!(["559999999999@s.whatsapp.net"]))]
+    pub mentions: Option<Vec<String>>,
+
+    /// When `true` and the recipient is a group chat (`@g.us`), mention
+    /// every group participant. Participant JIDs are fetched live from
+    /// the group metadata. Only meaningful for group recipients.
+    #[serde(default)]
+    pub mention_all: Option<bool>,
+
     /// Optional ISO-8601 UTC time to defer delivery until. When set in
     /// the future the message is parked in the scheduler and the API
     /// returns `status: "pending"` with a `schedule_id` instead of

--- a/src/models/sessions.rs
+++ b/src/models/sessions.rs
@@ -104,6 +104,16 @@ pub struct CreateSessionRequest {
     /// Optional friendly name for the session
     #[schema(example = "Business Account")]
     pub name: Option<String>,
+    /// When true and `id` already exists, re-scan the SAME session slot
+    /// instead of failing with 409: the existing session keeps its ID,
+    /// storage, webhooks, and DB row, and a fresh QR/pair connect is
+    /// started on it (same behavior as `POST /sessions/{id}/connect`).
+    /// This gives consumers a stable `session_id` across re-pairs
+    /// instead of fragmenting state over newly minted IDs. Ignored
+    /// webhook/name fields on reuse — update those via their own
+    /// endpoints. Has no effect when the ID does not exist yet.
+    #[serde(default)]
+    pub reuse: Option<bool>,
     /// Optional webhook configuration (session will auto-connect after creation)
     pub webhook: Option<WebhookRequest>,
     /// Optional device props override applied to the auto-spawned QR connect.
@@ -202,6 +212,11 @@ pub struct SessionStatusResponse {
     pub status: SessionStatus,
     /// Whether logged in
     pub is_logged_in: bool,
+    /// Whether the underlying socket is currently connected. Distinct
+    /// from `is_logged_in`: a cached `logged_in` status can outlive a
+    /// dead socket ("limbo"), and a live socket can precede login
+    /// during QR/pair flows.
+    pub socket_alive: bool,
     /// Phone number if available
     pub phone_number: Option<String>,
     /// Display name if available

--- a/src/models/webhooks.rs
+++ b/src/models/webhooks.rs
@@ -39,6 +39,12 @@ pub enum WebhookEvent {
 
     LoggedOut,
 
+    /// Server-side account lock (WA Web 403 / REASON_LOCKED). Emitted
+    /// instead of `logged_out` when the logout reason is a lock; the
+    /// payload carries the applied cooldown so operators can surface
+    /// "account locked, cool down" instead of a generic offline state.
+    AccountLocked,
+
     PictureUpdate,
 
     UserAboutUpdate,
@@ -89,6 +95,7 @@ impl WebhookEvent {
             WebhookEvent::Connected => event == "connected",
             WebhookEvent::Disconnected => event == "disconnected",
             WebhookEvent::LoggedOut => event == "logged_out",
+            WebhookEvent::AccountLocked => event == "account_locked",
             WebhookEvent::PictureUpdate => event == "picture_update",
             WebhookEvent::UserAboutUpdate => event == "user_about_update",
             WebhookEvent::PushNameUpdate => event == "push_name_update",
@@ -123,6 +130,7 @@ impl WebhookEvent {
             WebhookEvent::Connected => "connected",
             WebhookEvent::Disconnected => "disconnected",
             WebhookEvent::LoggedOut => "logged_out",
+            WebhookEvent::AccountLocked => "account_locked",
             WebhookEvent::PictureUpdate => "picture_update",
             WebhookEvent::UserAboutUpdate => "user_about_update",
             WebhookEvent::PushNameUpdate => "push_name_update",
@@ -160,6 +168,7 @@ impl WebhookEvent {
             "connected" => Some(WebhookEvent::Connected),
             "disconnected" => Some(WebhookEvent::Disconnected),
             "logged_out" => Some(WebhookEvent::LoggedOut),
+            "account_locked" => Some(WebhookEvent::AccountLocked),
             "picture_update" => Some(WebhookEvent::PictureUpdate),
             "user_about_update" => Some(WebhookEvent::UserAboutUpdate),
             "push_name_update" => Some(WebhookEvent::PushNameUpdate),
@@ -239,6 +248,42 @@ impl From<(String, WebhookConfig)> for WebhookConfigWithId {
 pub struct WebhookListResponse {
     /// List of webhooks, each with its ID so clients can DELETE by ID.
     pub webhooks: Vec<WebhookConfigWithId>,
+    /// Total count
+    pub count: usize,
+}
+
+/// A webhook delivery that exhausted every retry attempt and was parked
+/// for manual replay. Lives in a bounded per-session in-memory ring (see
+/// `WEBHOOK_DLQ_CAPACITY`) — the queue is lost on restart.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct WebhookDlqEntry {
+    /// DLQ entry ID, used by the replay endpoint.
+    pub id: String,
+    pub session_id: String,
+    pub webhook_url: String,
+    /// Event name that was being delivered (e.g. `message`).
+    pub event: String,
+    /// Raw JSON body, stored verbatim so replay re-delivers (and
+    /// re-signs) exactly what the consumer missed.
+    pub payload: String,
+    /// HMAC secret captured at failure time so replay signs identically
+    /// even if the webhook was re-registered with a different secret in
+    /// the meantime. Never leaves the process — skipped on serialize.
+    #[serde(skip)]
+    pub secret: Option<String>,
+    /// Error of the final attempt (HTTP status or transport error).
+    pub last_error: String,
+    /// How many delivery attempts were made before giving up.
+    pub attempts: usize,
+    /// Unix timestamp of the final failed attempt.
+    pub failed_at: i64,
+}
+
+/// Response with the session's dead-lettered webhook deliveries
+/// (newest first).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WebhookDlqListResponse {
+    pub entries: Vec<WebhookDlqEntry>,
     /// Total count
     pub count: usize,
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -548,6 +548,14 @@ fn session_routes() -> Router<AppState> {
             post(handlers::webhooks::register_webhook),
         )
         .route(
+            "/{session_id}/webhooks/dlq",
+            get(handlers::webhooks::list_webhook_dlq),
+        )
+        .route(
+            "/{session_id}/webhooks/dlq/{entry_id}/replay",
+            post(handlers::webhooks::replay_webhook_dlq_entry),
+        )
+        .route(
             "/{session_id}/webhooks/{webhook_id}",
             delete(handlers::webhooks::unregister_webhook),
         )
@@ -641,9 +649,30 @@ async fn readyz(
         .await
         .map(|s| s.len())
         .unwrap_or(0);
+    let session_states: Vec<serde_json::Value> = state
+        .session_iter_with_ids()
+        .iter()
+        .map(|(id, runtime)| {
+            json!({
+                "id": id,
+                "status": runtime.get_status().as_str(),
+                "socket_alive": runtime.socket_alive(),
+            })
+        })
+        .collect();
+    let sessions_live = session_states
+        .iter()
+        .filter(|s| {
+            s.get("socket_alive")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+        })
+        .count();
     let body = json!({
         "db": if db_ok { "ok" } else { "fail" },
         "sessions_known": sessions,
+        "sessions_live": sessions_live,
+        "sessions": session_states,
     });
     let status = if db_ok {
         StatusCode::OK

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,6 +16,7 @@
 
 use dashmap::DashMap;
 use parking_lot::RwLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -24,8 +25,107 @@ use whatsapp_rust::Client;
 use crate::db::session::DbPool;
 use crate::db::SessionManager;
 use crate::models::sessions::SessionStatus;
-use crate::models::webhooks::WebhookConfig;
+use crate::models::webhooks::{WebhookConfig, WebhookDlqEntry};
 use crate::nats::NatsManager;
+
+/// Value of the `X-Webhook-Signature-Version` header sent with every
+/// webhook delivery. `v2` = HMAC-SHA256 over `"{timestamp}.{body}"`
+/// (timestamp-prefixed, hex digest with a `sha256=` prefix); the legacy
+/// pre-0.9.8 scheme signed the raw body alone and carried no version
+/// header at all, so consumers can treat a missing header as `v1`.
+pub const WEBHOOK_SIGNATURE_VERSION: &str = "v2";
+
+/// Runtime retry/dead-letter policy for webhook delivery, read once at
+/// startup from the environment:
+///
+/// - `WEBHOOK_RETRY_MAX_ATTEMPTS` (default 3) — total delivery attempts
+///   per event before the payload lands in the DLQ. Backoff between
+///   attempts: immediate, +5 s, +30 s, then doubling (60 s, 120 s, ...)
+///   capped at 5 min.
+/// - `WEBHOOK_RETRY_ON_4XX` (default true) — also retry 4xx responses.
+///   A 401/403 window is usually a consumer-side auth misconfig that
+///   gets fixed; dropping those events on the first attempt loses
+///   messages for good. Set to `false` to restore the old "4xx is
+///   permanent" behavior (408/429 are retried either way).
+/// - `WEBHOOK_DLQ_CAPACITY` (default 100) — per-session in-memory DLQ
+///   ring size; oldest entries are evicted past the cap.
+#[derive(Clone, Debug)]
+pub struct WebhookRetryConfig {
+    pub max_attempts: usize,
+    pub retry_on_4xx: bool,
+    pub dlq_capacity: usize,
+}
+
+impl WebhookRetryConfig {
+    fn from_env() -> Self {
+        let max_attempts = std::env::var("WEBHOOK_RETRY_MAX_ATTEMPTS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(3);
+        let retry_on_4xx = std::env::var("WEBHOOK_RETRY_ON_4XX")
+            .map(|v| {
+                !matches!(
+                    v.to_ascii_lowercase().as_str(),
+                    "0" | "false" | "no" | "off"
+                )
+            })
+            .unwrap_or(true);
+        let dlq_capacity = std::env::var("WEBHOOK_DLQ_CAPACITY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(100);
+        Self {
+            max_attempts,
+            retry_on_4xx,
+            dlq_capacity,
+        }
+    }
+}
+
+/// Escalating cooldown applied when WhatsApp locks an account
+/// (`ConnectFailureReason::AccountLocked`, WA Web 403 / REASON_LOCKED).
+/// Read once at startup from `ACCOUNT_LOCK_BACKOFF_SECS` — a
+/// comma-separated list of cooldown seconds, default `300,900,3600`
+/// (5 min → 15 min → 60 min). The first lock applies step 0, the next
+/// lock inside the same process lifetime applies step 1, and so on; the
+/// last step repeats once the list is exhausted. A locked account only
+/// recovers when reconnect attempts stop, so a manual
+/// `POST /sessions/:id/connect` is the intended way out and clears the
+/// cooldown.
+#[derive(Clone, Debug)]
+pub struct AccountLockBackoffConfig {
+    pub schedule: Vec<i64>,
+}
+
+impl AccountLockBackoffConfig {
+    fn from_env() -> Self {
+        let schedule = std::env::var("ACCOUNT_LOCK_BACKOFF_SECS")
+            .ok()
+            .map(|raw| {
+                raw.split(',')
+                    .filter_map(|s| s.trim().parse::<i64>().ok())
+                    .filter(|n| *n > 0)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| vec![300, 900, 3600]);
+        Self { schedule }
+    }
+}
+
+/// Backoff before attempt `n` (0-based): the first try is immediate,
+/// then 5 s, 30 s, and doubling from 60 s afterwards, capped at 5 min.
+fn webhook_retry_delay(attempt: usize) -> Duration {
+    match attempt {
+        0 => Duration::ZERO,
+        1 => Duration::from_secs(5),
+        2 => Duration::from_secs(30),
+        n => Duration::from_secs(60u64.saturating_mul(2u64.saturating_pow((n - 3) as u32)))
+            .min(Duration::from_secs(300)),
+    }
+}
 
 /// Shared reqwest client for webhook delivery. Per-call `Client::new()` skips
 /// the connection pool and uses the OS-level TCP timeout (~75 s), so a
@@ -89,6 +189,31 @@ pub struct SessionState {
     /// long and needs a forced full rebuild rather than waiting on
     /// whatsapp-rust's own backoff indefinitely.
     pub reconnecting_since: RwLock<Option<i64>>,
+
+    /// Unix timestamp until which auto-reconnect is paused because the
+    /// server locked the account (`AccountLocked`). `None` = not locked.
+    /// In-memory only: after a restart the DB status is already
+    /// `Disconnected`, so the startup reconnect skips the session anyway
+    /// and the next lock event simply re-arms the cooldown. Cleared by a
+    /// manual `POST /sessions/:id/connect`.
+    pub lock_cooldown_until: RwLock<Option<i64>>,
+
+    /// Consecutive `AccountLocked` events seen in this process lifetime.
+    /// Indexes into [`AccountLockBackoffConfig::schedule`] so repeat
+    /// locks cool down for progressively longer.
+    pub lock_strikes: RwLock<u32>,
+
+    /// Operator's auto-reconnect preference, stored gateway-side so
+    /// `GET/PUT /sessions/:id/reconnect` work while the socket is down.
+    /// Applied to each freshly built client in `connect_client`; a live
+    /// client is also updated in place by the PUT handler. Defaults to
+    /// `true`, matching the historical hardcoded behavior.
+    pub auto_reconnect_pref: AtomicBool,
+
+    /// Same idea for `GET/PUT /sessions/:id/history-sync`: the
+    /// skip-history-sync flag, stored gateway-side and applied to every
+    /// newly built client.
+    pub skip_history_sync_pref: AtomicBool,
 }
 
 /// Snapshot of the latest pair attempt for a session. Lives entirely in
@@ -115,6 +240,61 @@ impl SessionState {
             logout_history: RwLock::new(Vec::new()),
             pair_state: RwLock::new(PairState::default()),
             reconnecting_since: RwLock::new(None),
+            lock_cooldown_until: RwLock::new(None),
+            lock_strikes: RwLock::new(0),
+            auto_reconnect_pref: AtomicBool::new(true),
+            skip_history_sync_pref: AtomicBool::new(false),
+        }
+    }
+
+    pub fn auto_reconnect_enabled(&self) -> bool {
+        self.auto_reconnect_pref.load(Ordering::Relaxed)
+    }
+
+    pub fn set_auto_reconnect_pref(&self, enabled: bool) {
+        self.auto_reconnect_pref.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn skip_history_sync(&self) -> bool {
+        self.skip_history_sync_pref.load(Ordering::Relaxed)
+    }
+
+    pub fn set_skip_history_sync_pref(&self, skip: bool) {
+        self.skip_history_sync_pref.store(skip, Ordering::Relaxed);
+    }
+
+    /// Record an `AccountLocked` event and return the cooldown just
+    /// applied as `(cooldown_secs, cooldown_until)`. Each strike walks
+    /// one step further down `schedule`, clamped at the last entry.
+    pub fn record_lock_cooldown(&self, schedule: &[i64]) -> (i64, i64) {
+        let mut strikes = self.lock_strikes.write();
+        *strikes = strikes.saturating_add(1);
+        let idx = (*strikes as usize)
+            .saturating_sub(1)
+            .min(schedule.len() - 1);
+        let secs = schedule[idx];
+        let until = chrono::Utc::now().timestamp() + secs;
+        *self.lock_cooldown_until.write() = Some(until);
+        (secs, until)
+    }
+
+    /// Manual intervention (`POST /sessions/:id/connect`): lift the
+    /// lock cooldown and reset the escalation ladder.
+    pub fn clear_lock_cooldown(&self) {
+        *self.lock_cooldown_until.write() = None;
+        *self.lock_strikes.write() = 0;
+    }
+
+    /// Seconds of lock cooldown remaining, or `None` when the session
+    /// is not currently paused. The watchdog and other self-heal paths
+    /// must skip the session while this is `Some`.
+    pub fn lock_cooldown_remaining(&self) -> Option<i64> {
+        let until = (*self.lock_cooldown_until.read())?;
+        let remaining = until - chrono::Utc::now().timestamp();
+        if remaining > 0 {
+            Some(remaining)
+        } else {
+            None
         }
     }
 
@@ -185,6 +365,18 @@ impl SessionState {
     pub fn is_alive(&self) -> bool {
         match self.client.read().as_ref() {
             Some(c) => c.is_connected() && c.is_logged_in(),
+            None => false,
+        }
+    }
+
+    /// Raw socket liveness, deliberately separate from [`Self::is_alive`]:
+    /// `true` as soon as the transport is connected, even before login
+    /// completes (QR/pair flows) — and `false` during the "limbo" where a
+    /// cached `LoggedIn` status outlives a dead socket. Surfaced as
+    /// `socket_alive` on /status, /readyz, and /metrics.
+    pub fn socket_alive(&self) -> bool {
+        match self.client.read().as_ref() {
+            Some(c) => c.is_connected(),
             None => false,
         }
     }
@@ -272,6 +464,20 @@ struct AppStateInner {
     pub recordings: crate::storage::RecordingStore,
 
     pub webhook_circuits: DashMap<String, CircuitState>,
+
+    /// Retry/dead-letter policy for webhook delivery (env-configurable,
+    /// see [`WebhookRetryConfig`]).
+    pub webhook_retry: WebhookRetryConfig,
+
+    /// Escalating cooldown schedule for server-side account locks
+    /// (env-configurable, see [`AccountLockBackoffConfig`]).
+    pub account_lock_backoff: AccountLockBackoffConfig,
+
+    /// Per-session dead-letter queue for webhook deliveries that
+    /// exhausted every retry attempt. Bounded ring per session
+    /// (`webhook_retry.dlq_capacity`), in-memory only — lost on restart
+    /// (the DB `webhook_dlq` table keeps a durable copy of each failure).
+    pub webhook_dlq: DashMap<String, std::collections::VecDeque<WebhookDlqEntry>>,
 
     pub incoming_calls: DashMap<String, wacore::types::call::IncomingCall>,
 
@@ -364,6 +570,9 @@ impl AppState {
                 nats,
                 recordings,
                 webhook_circuits: DashMap::new(),
+                webhook_retry: WebhookRetryConfig::from_env(),
+                account_lock_backoff: AccountLockBackoffConfig::from_env(),
+                webhook_dlq: DashMap::new(),
                 incoming_calls: DashMap::new(),
                 active_calls: DashMap::new(),
                 call_audio_channels: DashMap::new(),
@@ -644,6 +853,41 @@ impl AppState {
 
     pub fn purge_webhooks_for_session(&self, session_id: &str) {
         self.inner.webhooks.remove(session_id);
+        self.inner.webhook_dlq.remove(session_id);
+    }
+
+    /// Push a permanently-failed delivery onto the session's in-memory
+    /// DLQ ring, evicting the oldest entries past the configured
+    /// capacity.
+    pub fn webhook_dlq_push(&self, entry: WebhookDlqEntry) {
+        let capacity = self.inner.webhook_retry.dlq_capacity;
+        let mut ring = self
+            .inner
+            .webhook_dlq
+            .entry(entry.session_id.clone())
+            .or_default();
+        while ring.len() >= capacity {
+            ring.pop_front();
+        }
+        ring.push_back(entry);
+    }
+
+    /// List the session's DLQ entries, newest first.
+    pub fn webhook_dlq_list(&self, session_id: &str) -> Vec<WebhookDlqEntry> {
+        self.inner
+            .webhook_dlq
+            .get(session_id)
+            .map(|r| r.value().iter().rev().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Remove and return one DLQ entry. Used by the replay endpoint —
+    /// the re-delivery goes through the same delivery path and re-enters
+    /// the queue on its own if it fails again.
+    pub fn webhook_dlq_take(&self, session_id: &str, entry_id: &str) -> Option<WebhookDlqEntry> {
+        let mut ring = self.inner.webhook_dlq.get_mut(session_id)?;
+        let pos = ring.iter().position(|e| e.id == entry_id)?;
+        ring.remove(pos)
     }
 
     /// Bulk close-and-reset every open circuit. Used by
@@ -690,6 +934,10 @@ impl AppState {
 
     pub fn session_manager(&self) -> &SessionManager {
         &self.inner.session_manager
+    }
+
+    pub fn account_lock_backoff(&self) -> &AccountLockBackoffConfig {
+        &self.inner.account_lock_backoff
     }
 
     pub fn base_storage_path(&self) -> &str {
@@ -774,15 +1022,19 @@ impl AppState {
     /// replay forever with a still-valid signature. Binding the signature
     /// to a timestamp that ships alongside it lets a receiver reject
     /// anything outside a short window -- see webhooks.md for the
-    /// verification recipe receivers are expected to implement.
+    /// verification recipe receivers are expected to implement. Every
+    /// delivery also carries `X-Webhook-Signature-Version: v2`
+    /// ([`WEBHOOK_SIGNATURE_VERSION`]) so consumers can detect the
+    /// timestamp-prefixed scheme introduced in v0.9.8.
+    ///
+    /// Each webhook's delivery runs in its own spawned task
+    /// ([`Self::deliver_webhook`]) with configurable retries and a
+    /// dead-letter queue, so a slow or dead target never blocks the
+    /// event pipeline.
     pub async fn broadcast_to_webhooks(&self, session_id: &str, event: &str, payload: &str) {
         self.push_event(session_id, event, payload);
 
         let webhooks = self.get_webhooks(session_id);
-        let client = webhook_client();
-        let pool = self.session_manager().pool().clone();
-        let session_id_owned = session_id.to_string();
-        let event_owned = event.to_string();
 
         for (_, config) in webhooks {
             if !config.enabled {
@@ -797,124 +1049,179 @@ impl AppState {
                 continue;
             }
 
-            let url = config.url.clone();
-            let payload = payload.to_string();
-            let secret = config.secret.clone();
-            let client = client.clone();
-            let pool = pool.clone();
-            let session_id_owned = session_id_owned.clone();
-            let event_owned = event_owned.clone();
             let state_for_task = self.clone();
+            let session_id_owned = session_id.to_string();
+            let event_owned = event.to_string();
+            let payload_owned = payload.to_string();
 
             tokio::spawn(async move {
-                let backoff_ms = [0u64, 1000, 3000, 7000];
-                let mut last_err: Option<String> = None;
-                for (i, delay) in backoff_ms.iter().enumerate() {
-                    if *delay > 0 {
-                        tokio::time::sleep(Duration::from_millis(*delay)).await;
-                    }
-
-                    let timestamp = chrono::Utc::now().timestamp();
-                    let mut req = client
-                        .post(&url)
-                        .header("Content-Type", "application/json")
-                        .header("X-Webhook-Timestamp", timestamp.to_string())
-                        .body(payload.clone());
-
-                    if let Some(secret) = &secret {
-                        use hmac::{Hmac, Mac};
-                        use sha2::Sha256;
-
-                        type HmacSha256 = Hmac<Sha256>;
-                        if let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) {
-                            mac.update(format!("{timestamp}.{payload}").as_bytes());
-                            let signature = hex::encode(mac.finalize().into_bytes());
-                            req =
-                                req.header("X-Webhook-Signature", format!("sha256={}", signature));
-                        }
-                    }
-
-                    match req.send().await {
-                        Ok(resp) => {
-                            let status = resp.status();
-                            if status.is_success() {
-                                state_for_task.webhook_record_success(&url);
-                                return;
-                            }
-                            if status.is_client_error()
-                                && status.as_u16() != 408
-                                && status.as_u16() != 429
-                            {
-                                tracing::warn!(
-                                    "Webhook {} rejected with {} — not retrying",
-                                    url,
-                                    status
-                                );
-                                return;
-                            }
-                            last_err = Some(format!("HTTP {}", status));
-                        }
-                        Err(e) => {
-                            last_err = Some(e.to_string());
-                        }
-                    }
-                    let _ = i;
-                }
-                if let Some(err) = last_err {
-                    let action = state_for_task.webhook_record_failure(&url);
-                    match action {
-                        WebhookFailureAction::HardDisable => {
-                            tracing::warn!(
-                                "Webhook {} auto-DISABLED after 100 consecutive failures — DB row switched to enabled=false",
-                                url
-                            );
-                            let reason = format!("100 consecutive failures ({err})");
-                            match state_for_task
-                                .session_manager()
-                                .disable_webhook_by_url(&url, &reason)
-                                .await
-                            {
-                                Ok(n) => tracing::info!(
-                                    "webhook auto-disable: {} row(s) marked enabled=false for {}",
-                                    n,
-                                    url
-                                ),
-                                Err(err) => tracing::warn!(
-                                    "webhook auto-disable persist failed for {}: {}",
-                                    url,
-                                    err
-                                ),
-                            }
-                            state_for_task.purge_webhook_by_url(&url);
-                        }
-                        WebhookFailureAction::Open => {
-                            tracing::warn!(
-                                "Webhook {} circuit OPEN after 25 consecutive failures — skipping dispatch for 5 min",
-                                url
-                            );
-                        }
-                        WebhookFailureAction::Noop => {
-                            tracing::warn!(
-                                "Failed to send webhook to {} after {} attempts: {}",
-                                url,
-                                backoff_ms.len(),
-                                err
-                            );
-                        }
-                    }
-                    crate::db::webhook_dlq::record_failure(
-                        &pool,
+                state_for_task
+                    .deliver_webhook(
                         &session_id_owned,
-                        &url,
                         &event_owned,
-                        &payload,
-                        &err,
-                        backoff_ms.len() as i32,
+                        &config.url,
+                        config.secret,
+                        &payload_owned,
                     )
                     .await;
-                }
             });
         }
+    }
+
+    /// One full delivery run of `payload` against `url`: up to
+    /// `WEBHOOK_RETRY_MAX_ATTEMPTS` tries with exponential backoff
+    /// (immediate, +5 s, +30 s, ...), HMAC-signing each attempt when
+    /// `secret` is set. Retries cover 5xx and transport errors, plus
+    /// 4xx when `WEBHOOK_RETRY_ON_4XX` is on (the default — a 401/403
+    /// window is usually a fixable consumer misconfig, and dropping
+    /// those events loses messages).
+    ///
+    /// When every attempt fails the failure is recorded against the
+    /// per-URL circuit breaker and the payload is dead-lettered — onto
+    /// the session's bounded in-memory DLQ (replayable via
+    /// `POST .../webhooks/dlq/{entry_id}/replay`) and into the DB
+    /// `webhook_dlq` table. Returns `true` when a delivery succeeded.
+    ///
+    /// Used both by [`Self::broadcast_to_webhooks`] (fresh events) and
+    /// by the DLQ replay endpoint (stored payloads), so both paths
+    /// share the exact same signing and retry behavior.
+    pub async fn deliver_webhook(
+        &self,
+        session_id: &str,
+        event: &str,
+        url: &str,
+        secret: Option<String>,
+        payload: &str,
+    ) -> bool {
+        let retry_cfg = self.inner.webhook_retry.clone();
+        let max_attempts = retry_cfg.max_attempts.max(1);
+        let client = webhook_client();
+        let pool = self.session_manager().pool().clone();
+        let mut last_err: Option<String> = None;
+
+        for attempt in 0..max_attempts {
+            let delay = webhook_retry_delay(attempt);
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+
+            let timestamp = chrono::Utc::now().timestamp();
+            let mut req = client
+                .post(url)
+                .header("Content-Type", "application/json")
+                .header("X-Webhook-Timestamp", timestamp.to_string())
+                .header("X-Webhook-Signature-Version", WEBHOOK_SIGNATURE_VERSION)
+                .body(payload.to_string());
+
+            if let Some(secret) = &secret {
+                use hmac::{Hmac, Mac};
+                use sha2::Sha256;
+
+                type HmacSha256 = Hmac<Sha256>;
+                if let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) {
+                    mac.update(format!("{timestamp}.{payload}").as_bytes());
+                    let signature = hex::encode(mac.finalize().into_bytes());
+                    req = req.header("X-Webhook-Signature", format!("sha256={}", signature));
+                }
+            }
+
+            match req.send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        self.webhook_record_success(url);
+                        return true;
+                    }
+                    if !retry_cfg.retry_on_4xx
+                        && status.is_client_error()
+                        && status.as_u16() != 408
+                        && status.as_u16() != 429
+                    {
+                        tracing::warn!(
+                            "Webhook {} rejected with {} — not retrying (WEBHOOK_RETRY_ON_4XX=false), dead-lettering",
+                            url,
+                            status
+                        );
+                        last_err = Some(format!("HTTP {}", status));
+                        break;
+                    }
+                    last_err = Some(format!("HTTP {}", status));
+                }
+                Err(e) => {
+                    last_err = Some(e.to_string());
+                }
+            }
+        }
+
+        let err = match last_err {
+            Some(err) => err,
+            None => return false,
+        };
+
+        let action = self.webhook_record_failure(url);
+        match action {
+            WebhookFailureAction::HardDisable => {
+                tracing::warn!(
+                    "Webhook {} auto-DISABLED after 100 consecutive failures — DB row switched to enabled=false",
+                    url
+                );
+                let reason = format!("100 consecutive failures ({err})");
+                match self
+                    .session_manager()
+                    .disable_webhook_by_url(url, &reason)
+                    .await
+                {
+                    Ok(n) => tracing::info!(
+                        "webhook auto-disable: {} row(s) marked enabled=false for {}",
+                        n,
+                        url
+                    ),
+                    Err(err) => {
+                        tracing::warn!("webhook auto-disable persist failed for {}: {}", url, err)
+                    }
+                }
+                self.purge_webhook_by_url(url);
+            }
+            WebhookFailureAction::Open => {
+                tracing::warn!(
+                    "Webhook {} circuit OPEN after 25 consecutive failures — skipping dispatch for 5 min",
+                    url
+                );
+            }
+            WebhookFailureAction::Noop => {
+                tracing::warn!(
+                    "Failed to send webhook to {} after {} attempts: {}",
+                    url,
+                    max_attempts,
+                    err
+                );
+            }
+        }
+
+        self.webhook_dlq_push(WebhookDlqEntry {
+            id: uuid::Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            webhook_url: url.to_string(),
+            event: event.to_string(),
+            payload: payload.to_string(),
+            secret,
+            last_error: err.clone(),
+            attempts: max_attempts,
+            failed_at: chrono::Utc::now().timestamp(),
+        });
+
+        crate::db::webhook_dlq::record_failure(
+            &pool,
+            session_id,
+            url,
+            event,
+            payload,
+            &err,
+            max_attempts as i32,
+        )
+        .await;
+
+        false
     }
 }
 

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -254,3 +254,233 @@ async fn get_session_status_shape_matches_list_entry() {
     assert_eq!(get_status_str, entry_status);
     assert_eq!(get_logged, entry_logged);
 }
+
+/// Issue #70: `GET/PUT /sessions/{id}/reconnect` used to 503 whenever the
+/// socket was down — but toggling auto-reconnect is exactly what's needed
+/// while a session is down. The endpoints now serve the stored preference
+/// from the session runtime, so they must answer 200 with no live client.
+#[tokio::test]
+async fn reconnect_config_is_serviceable_without_live_socket() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-rc"}),
+        ),
+    )
+    .await;
+
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-rc/reconnect", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("enabled").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(body.get("error_count").and_then(|v| v.as_u64()), Some(0));
+
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::PUT,
+            "/api/v1/sessions/s-rc/reconnect",
+            Some(TEST_TOKEN),
+            json!({"enabled": false}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("enabled").and_then(|v| v.as_bool()), Some(false));
+
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-rc/reconnect", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.get("enabled").and_then(|v| v.as_bool()),
+        Some(false),
+        "the preference must persist on the runtime, not the live client"
+    );
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/ghost/reconnect", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// Issue #70, same flaw on the history-sync config pair.
+#[tokio::test]
+async fn history_sync_config_is_serviceable_without_live_socket() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-hs"}),
+        ),
+    )
+    .await;
+
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-hs/history-sync", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.get("skip_history_sync").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::PUT,
+            "/api/v1/sessions/s-hs/history-sync",
+            Some(TEST_TOKEN),
+            json!({"skip": true}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.get("skip_history_sync").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/ghost/history-sync", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// Issue #71: /status must expose raw socket liveness separately from
+/// `is_logged_in`, so a cached `logged_in` that outlives its socket
+/// ("limbo") is detectable. With no client attached the field is false.
+#[tokio::test]
+async fn status_reports_socket_alive_separately_from_login_state() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-limbo"}),
+        ),
+    )
+    .await;
+
+    let runtime = h.state.get_or_create_session("s-limbo", "/tmp/s-limbo");
+    runtime.set_status(waxum::models::sessions::SessionStatus::LoggedIn);
+
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-limbo/status", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.get("is_logged_in").and_then(|v| v.as_bool()),
+        Some(true),
+        "cached login state is still reported (status degrades to connecting)"
+    );
+    assert_eq!(
+        body.get("socket_alive").and_then(|v| v.as_bool()),
+        Some(false),
+        "no live client means the socket is down regardless of cached status"
+    );
+}
+
+/// Issue #69: re-scanning must be possible on the SAME session slot so a
+/// consumer's `session_id`-keyed state survives a re-pair. Without
+/// `reuse`, an existing ID still conflicts; with `reuse: true` the same
+/// row is returned and a fresh connect is started on it.
+#[tokio::test]
+async fn create_with_reuse_keeps_session_id_on_repair() {
+    let h = Harness::new().await;
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-repair", "name": "Original"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.pointer("/session/id").and_then(|v| v.as_str()),
+        Some("s-repair")
+    );
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-repair"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-repair", "reuse": true}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.pointer("/session/id").and_then(|v| v.as_str()),
+        Some("s-repair")
+    );
+    assert_eq!(
+        body.pointer("/session/name").and_then(|v| v.as_str()),
+        Some("Original"),
+        "reuse must keep the existing DB row, not overwrite it"
+    );
+
+    let (_, list) = call(&h.app, req_get("/api/v1/sessions", Some(TEST_TOKEN))).await;
+    assert_eq!(list.get("total").and_then(|v| v.as_u64()), Some(1));
+}
+
+/// Issue #69: `reuse: true` on an ID that does not exist yet just
+/// behaves like a normal create.
+#[tokio::test]
+async fn create_with_reuse_on_unknown_id_creates_normally() {
+    let h = Harness::new().await;
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-fresh", "reuse": true}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.pointer("/session/id").and_then(|v| v.as_str()),
+        Some("s-fresh")
+    );
+}

--- a/tests/webhooks.rs
+++ b/tests/webhooks.rs
@@ -142,3 +142,38 @@ async fn reenable_missing_webhook_returns_404() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn dlq_list_empty_when_nothing_failed() {
+    let h = Harness::new().await;
+    seed_session(&h, "wh-s-06").await;
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/wh-s-06/webhooks/dlq", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("count").and_then(|v| v.as_u64()), Some(0));
+    assert!(body
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn dlq_replay_missing_entry_returns_404() {
+    let h = Harness::new().await;
+    seed_session(&h, "wh-s-07").await;
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/wh-s-07/webhooks/dlq/does-not-exist/replay",
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Resolves all 8 open issues. Full test suite green (84 passed, 0 failed); `cargo fmt`/`clippy -D warnings`/`build` pass.

### Reconnect / sessions
- **#66** — `AccountLocked` is no longer treated as a transient flap: auto-reconnect is paused behind an escalating cooldown (`ACCOUNT_LOCK_BACKOFF_SECS`, default `300,900,3600`), a distinct `account_locked` event is emitted (webhooks/NATS/broadcast, new `WebhookEvent::AccountLocked`), and locks never count toward the flap-purge threshold. Manual `POST .../connect` lifts the cooldown.
- **#69** — `POST /sessions` accepts `reuse: true`: re-scanning an existing slot keeps the original `session_id`, DB row, storage, and webhooks instead of 409 / minting a new id.
- **#70** — `GET/PUT /sessions/:id/reconnect` and `/history-sync` are served from stored per-session prefs (404 unknown, never 503); prefs mirror onto live clients and apply on connect.
- **#71** — `socket_alive` added to `GET /sessions/:id/status` (distinct from `is_logged_in`); new prometheus series `waxum_session_socket_alive`, `waxum_session_socket_drops_total`, `waxum_session_reconnects_total`; `/readyz` reports `sessions_live` + per-session state.

### Webhooks
- **#67** — every delivery carries `X-Webhook-Signature-Version: v2`; the timestamp-prefixed HMAC scheme (`HMAC-SHA256("{timestamp}.{body}")`, hex, `sha256=` prefix) is documented as **BREAKING** in the CHANGELOG and webhook docs.
- **#68** — failed deliveries retry with configurable backoff (`WEBHOOK_RETRY_MAX_ATTEMPTS=3`, `WEBHOOK_RETRY_ON_4XX=true`, 5s→30s→doubling, cap 5min); exhausted deliveries land in a bounded in-memory DLQ (`WEBHOOK_DLQ_CAPACITY=100`) with `GET .../webhooks/dlq` and `POST .../webhooks/dlq/{id}/replay`. Circuit breaker respected; durable DB record kept.

### Messages
- **#72** — investigation confirmed the pinned whatsapp-rust already replays down-window messages via `OfflineDrain` batches through the live event path; payloads now carry `offline: true|false` so consumers can distinguish redeliveries (additive, backward compatible).
- **#73** — `POST /sessions/:id/messages/text` accepts `mentions: [jid|number]` (auto-renders `@user` tokens) and `mention_all: true` (group-only, live participant fetch, silent attach). Works through the scheduler path.

## Caveats
- DLQ and lock cooldown are in-memory (lost on restart, by design); the DB `webhook_dlq` table remains the durable failure record.
- #72 has no HTTP-level regression test (needs a live client); verified by compilation + existing suites.
- `TemporaryBan` events don't get cooldowns (the crate dispatches them with server-supplied expiry).

Closes #66, closes #67, closes #68, closes #69, closes #70, closes #71, closes #72, closes #73.