### PR TITLE
feat: sync with whatsapp-rust 8cea605f (pause/resume, app-state resync, message paging, new events)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+Bumped the vendored `whatsapp-rust` (and `wacore`/`wacore-binary`/
+`waproto`/`whatsapp-rust-sqlite-storage`/`whatsapp-rust-tokio-transport`/
+`whatsapp-rust-ureq-http-client`) git rev from `5e084b9b` to `8cea605f`
+(upstream `0.7.0`), and added `whatsapp-rust-chat-store` at the same rev.
+No compile breaks from the bump itself; the new upstream capabilities are
+wired below.
+
+### Added — new webhook/NATS events
+
+Three new upstream events now fan out to webhooks, NATS and the console
+event feed, with matching `WebhookEvent` values for subscription
+filtering:
+
+- `call_log_sync` — a call-history record synced from the primary device
+  (upstream `Event::CallLogSync`). Payload carries `call_creator_jid`,
+  `call_id`, `from_me`, `timestamp`, `from_full_sync` and the raw record.
+- `stream_error` — a server-side stream error stanza such as a 429 rate
+  limit (upstream `Event::StreamError`). Payload carries `code`.
+- `enc_decrypt_failed` — an inbound `<enc>` that produced no plaintext,
+  with the reason (upstream `Event::EncDecryptFailed`). Payload carries
+  `chat`, `sender`, `message_id`, `enc_index`, `enc_type` and `reason`.
+  Upstream gates this event behind a forwarding lease; the gateway now
+  acquires `Client::acquire_enc_decrypt_failed_forwarding()` for every
+  connected client so the event actually fires.
+
+### Added — `POST /sessions/{id}/pause` + `POST /sessions/{id}/resume`
+
+Take a session offline and bring it back on the caller's word (upstream
+`Client::pause`/`resume`/`is_paused`). Both return `{"paused": bool}`;
+both require an installed client (503 otherwise). `GET /sessions/{id}/status`
+gained a `paused` field sourced from `Client::is_paused()` (`false` when
+no client is installed).
+
+### Added — `POST /sessions/{id}/appstate/resync`
+
+Consumer-driven re-sync of app-state collections (upstream
+`Client::resync_app_state`). Body: `{"collections": ["critical_block",
+"critical_unblock_low", "regular_low", "regular_high", "regular"], "mode":
+"incremental"|"snapshot"}` (`mode` defaults to `incremental`; `snapshot`
+discards stored state and rebuilds from the server's snapshot). Returns
+the per-collection report `{"synced", "fatal", "retryable", "skipped",
+"all_synced"}`. Unknown collection names and unknown modes are rejected
+with 400 before any request reaches the wire; requires a live client
+(503 otherwise).
+
+### Added — `GET /sessions/{id}/messages`
+
+Session-wide message listing in store-arrival order (newest first),
+backed by the upstream chat store's `messages_by_arrival`, which the
+gateway now materializes into each session's `whatsapp.db`. Keyset
+pagination: `?after=<seq>&limit=<n>` (default 20, max 200), with the
+response's `next_cursor` passed back as `after` for the next (older)
+page; `next_cursor` is `null` on a short page. Per-message fields mirror
+the chat-scoped listing (`id`, `message_id`, `session_id`, `chat_jid`,
+`sender_jid`, `direction`, `msg_type`, `body`, `msg_timestamp`,
+`push_name`, `media` download pointer). Requires a live client (503 when
+no chat store is installed).
+
 ## [0.12.0] - 2026-08-10
 
 ### BREAKING — webhook signature scheme is now versioned (`v2`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -4967,7 +4967,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "wacore"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.0",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "wacore-appstate"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "bytes",
  "compact_str",
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "wacore-derive"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "aes 0.9.2",
  "async-lock",
@@ -5096,7 +5096,7 @@ dependencies = [
 [[package]]
 name = "wacore-noise"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "anyhow",
  "buffa",
@@ -5133,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -5286,6 +5286,7 @@ dependencies = [
  "wacore-binary",
  "waproto",
  "whatsapp-rust",
+ "whatsapp-rust-chat-store",
  "whatsapp-rust-sqlite-storage",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
@@ -5463,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5506,9 +5507,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "whatsapp-rust-chat-store"
+version = "0.1.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+dependencies = [
+ "buffa",
+ "chrono",
+ "diesel",
+ "diesel_migrations",
+ "log",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "wacore",
+ "wacore-binary",
+ "waproto",
+ "whatsapp-rust-sqlite-storage",
+]
+
+[[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "async-trait",
  "buffa",
@@ -5528,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-tokio-transport"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5548,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=5e084b9ba26bab12e22f8084843e225a5dc1bd3c#5e084b9ba26bab12e22f8084843e225a5dc1bd3c"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ repository = "https://github.com/imtaqin/waxum"
 [dependencies]
 
 rand = "0.8"
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c", default-features = true, features = ["voip", "tracing"] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c" }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c" }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c" }
-whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c" }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c" }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "5e084b9ba26bab12e22f8084843e225a5dc1bd3c" }
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928", default-features = true, features = ["voip", "tracing"] }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+whatsapp-rust-chat-store = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
 
 # Web framework
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }

--- a/src/handlers/operations.rs
+++ b/src/handlers/operations.rs
@@ -429,6 +429,67 @@ pub async fn get_history_sync(
     }))
 }
 
+/// Response of the pause/resume endpoints.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct PauseStateResponse {
+    /// Whether the session is paused after the operation.
+    pub paused: bool,
+}
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/pause",
+    tag = "operations",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    responses(
+        (status = 200, description = "Session paused", body = PauseStateResponse),
+        (status = 404, description = "Session not found"),
+        (status = 503, description = "Not connected")
+    )
+)]
+pub async fn pause_session(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<PauseStateResponse>, ApiError> {
+    let client = get_installed_client(&state, &session_id)?;
+
+    client.pause().await;
+
+    Ok(Json(PauseStateResponse {
+        paused: client.is_paused(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/resume",
+    tag = "operations",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    responses(
+        (status = 200, description = "Session resumed", body = PauseStateResponse),
+        (status = 404, description = "Session not found"),
+        (status = 503, description = "Not connected")
+    )
+)]
+pub async fn resume_session(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<Json<PauseStateResponse>, ApiError> {
+    let client = get_installed_client(&state, &session_id)?;
+
+    client.resume();
+
+    Ok(Json(PauseStateResponse {
+        paused: client.is_paused(),
+    }))
+}
+
 fn get_client(
     state: &AppState,
     session_id: &str,
@@ -438,6 +499,144 @@ fn get_client(
         .ok_or(ApiError::NotConnected)?;
 
     runtime.get_live_client().ok_or(ApiError::NotConnected)
+}
+
+/// Resolve the installed client without requiring a live socket. A paused
+/// session has no connection by definition, so pause/resume must not gate
+/// on [`SessionState::get_live_client`] the way send-path handlers do;
+/// they only need the client instance itself to be installed.
+fn get_installed_client(
+    state: &AppState,
+    session_id: &str,
+) -> Result<std::sync::Arc<whatsapp_rust::Client>, ApiError> {
+    let runtime = state
+        .get_session(session_id)
+        .ok_or(ApiError::NotConnected)?;
+
+    runtime.get_client().ok_or(ApiError::NotConnected)
+}
+
+/// Request body for `POST /sessions/{id}/appstate/resync`.
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct AppStateResyncRequest {
+    /// Collections to re-fetch: `critical_block`, `critical_unblock_low`,
+    /// `regular_low`, `regular_high`, `regular`.
+    pub collections: Vec<String>,
+    /// `incremental` (default) asks for patches after the stored version;
+    /// `snapshot` discards the stored state and rebuilds the collection
+    /// from the server's snapshot.
+    pub mode: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+pub struct AppStateResyncResponse {
+    /// Fetched, applied and persisted.
+    pub synced: Vec<String>,
+    /// Refused by the server outright (400/404); retrying will not clear these.
+    pub fatal: Vec<String>,
+    /// Not synced, but a later attempt can succeed.
+    pub retryable: Vec<String>,
+    /// Left to another sync already fetching the collection.
+    pub skipped: Vec<String>,
+    /// True when every requested collection came back synced.
+    pub all_synced: bool,
+}
+
+/// Parse one collection name against upstream's [`whatsapp_rust::WAPatchName`],
+/// rejecting anything that falls back to `Unknown` — that variant is a parse
+/// fallback, not a collection the server has, and upstream refuses a request
+/// that names it.
+fn parse_patch_name(name: &str) -> Result<whatsapp_rust::WAPatchName, ApiError> {
+    use std::str::FromStr;
+
+    let parsed =
+        whatsapp_rust::WAPatchName::from_str(name).unwrap_or(whatsapp_rust::WAPatchName::Unknown);
+    if parsed == whatsapp_rust::WAPatchName::Unknown {
+        return Err(ApiError::BadRequest(format!(
+            "unknown app-state collection: {name} (expected one of: critical_block, \
+             critical_unblock_low, regular_low, regular_high, regular)"
+        )));
+    }
+    Ok(parsed)
+}
+
+fn parse_resync_mode(mode: Option<&str>) -> Result<whatsapp_rust::AppStateResyncMode, ApiError> {
+    match mode {
+        None | Some("incremental") => Ok(whatsapp_rust::AppStateResyncMode::Incremental),
+        Some("snapshot") => Ok(whatsapp_rust::AppStateResyncMode::Snapshot),
+        Some(other) => Err(ApiError::BadRequest(format!(
+            "unknown resync mode: {other} (expected \"incremental\" or \"snapshot\")"
+        ))),
+    }
+}
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/appstate/resync",
+    tag = "operations",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    request_body = AppStateResyncRequest,
+    responses(
+        (status = 200, description = "App-state resync report", body = AppStateResyncResponse),
+        (status = 400, description = "Invalid request"),
+        (status = 404, description = "Session not found"),
+        (status = 503, description = "Not connected")
+    )
+)]
+pub async fn appstate_resync(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(request): Json<AppStateResyncRequest>,
+) -> Result<Json<AppStateResyncResponse>, ApiError> {
+    if request.collections.is_empty() {
+        return Err(ApiError::BadRequest(
+            "collections must not be empty".to_string(),
+        ));
+    }
+    let collections = request
+        .collections
+        .iter()
+        .map(|name| parse_patch_name(name))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mode = parse_resync_mode(request.mode.as_deref())?;
+
+    let client = get_client(&state, &session_id)?;
+    let report = client
+        .resync_app_state(collections, mode)
+        .await
+        .map_err(|e| match e {
+            whatsapp_rust::AppStateError::NotConnected => ApiError::NotConnected,
+            whatsapp_rust::AppStateError::InvalidRequest(msg) => ApiError::BadRequest(msg),
+            whatsapp_rust::AppStateError::Internal(err) => ApiError::Internal(err.to_string()),
+            other => ApiError::Internal(other.to_string()),
+        })?;
+
+    Ok(Json(AppStateResyncResponse {
+        synced: report
+            .synced
+            .iter()
+            .map(|n| n.as_str().to_string())
+            .collect(),
+        fatal: report
+            .fatal
+            .iter()
+            .map(|n| n.as_str().to_string())
+            .collect(),
+        retryable: report
+            .retryable
+            .iter()
+            .map(|n| n.as_str().to_string())
+            .collect(),
+        skipped: report
+            .skipped
+            .iter()
+            .map(|n| n.as_str().to_string())
+            .collect(),
+        all_synced: report.all_synced(),
+    }))
 }
 
 /// Resolve the session's runtime for per-session config read/write
@@ -469,4 +668,50 @@ async fn config_runtime(
         .unwrap_or_else(|| format!("{}/{}", state.base_storage_path(), session_id));
 
     Ok(state.get_or_create_session(session_id, &storage_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_patch_name_accepts_every_real_collection() {
+        for (name, expected) in [
+            ("critical_block", whatsapp_rust::WAPatchName::CriticalBlock),
+            (
+                "critical_unblock_low",
+                whatsapp_rust::WAPatchName::CriticalUnblockLow,
+            ),
+            ("regular_low", whatsapp_rust::WAPatchName::RegularLow),
+            ("regular_high", whatsapp_rust::WAPatchName::RegularHigh),
+            ("regular", whatsapp_rust::WAPatchName::Regular),
+        ] {
+            assert_eq!(parse_patch_name(name).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn parse_patch_name_rejects_unknown_and_the_unknown_fallback() {
+        assert!(parse_patch_name("bogus").is_err());
+        assert!(parse_patch_name("").is_err());
+        assert!(parse_patch_name("unknown").is_err());
+        assert!(parse_patch_name("Critical_Block").is_err());
+    }
+
+    #[test]
+    fn parse_resync_mode_defaults_to_incremental() {
+        assert_eq!(
+            parse_resync_mode(None).unwrap(),
+            whatsapp_rust::AppStateResyncMode::Incremental
+        );
+        assert_eq!(
+            parse_resync_mode(Some("incremental")).unwrap(),
+            whatsapp_rust::AppStateResyncMode::Incremental
+        );
+        assert_eq!(
+            parse_resync_mode(Some("snapshot")).unwrap(),
+            whatsapp_rust::AppStateResyncMode::Snapshot
+        );
+        assert!(parse_resync_mode(Some("full")).is_err());
+    }
 }

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -26,13 +26,14 @@ use axum::{
     Json,
 };
 use wacore_binary::jid::Jid;
+use whatsapp_rust_chat_store::{ArrivalCursor, MessageKind};
 
 use crate::db::messages::{self, MediaPointer, MessageRow, NewMessage};
 use crate::error::ApiError;
 use crate::models::media::MediaType;
 use crate::models::search::{
     ChatMessagesQuery, MessageFleetSearchQuery, MessageHit, MessageMedia, MessageSearchQuery,
-    MessageSearchResponse,
+    MessageSearchResponse, SessionMessagesQuery, SessionMessagesResponse,
 };
 use crate::state::AppState;
 
@@ -226,6 +227,129 @@ pub async fn list_chat_messages(
     Ok(Json(rows_to_response(rows)))
 }
 
+/// Map the upstream chat store's [`MessageKind`] to the `msg_type` slugs
+/// the rest of the gateway uses (`text`, `image`, `ptt`, ...).
+fn message_kind_slug(kind: &MessageKind) -> String {
+    match kind {
+        MessageKind::Text => "text",
+        MessageKind::Image => "image",
+        MessageKind::Video => "video",
+        MessageKind::VideoNote => "video_note",
+        MessageKind::Audio => "audio",
+        MessageKind::VoiceNote => "ptt",
+        MessageKind::Sticker => "sticker",
+        MessageKind::Document => "document",
+        MessageKind::Contact => "contact",
+        MessageKind::Location => "location",
+        MessageKind::Poll => "poll",
+        MessageKind::Event => "event",
+        MessageKind::GroupInvite => "group_invite",
+        MessageKind::Template => "template",
+        MessageKind::TemplateReply => "template_reply",
+        MessageKind::Buttons => "buttons",
+        MessageKind::ButtonsResponse => "buttons_response",
+        MessageKind::List => "list",
+        MessageKind::ListResponse => "list_response",
+        MessageKind::Interactive => "interactive",
+        MessageKind::InteractiveResponse => "interactive_response",
+        MessageKind::Undecryptable => "undecryptable",
+        MessageKind::ViewOnce => "view_once",
+        MessageKind::Hosted => "hosted",
+        MessageKind::Bot => "bot",
+        MessageKind::Unknown => "unknown",
+        MessageKind::Other(slug) => slug.as_str(),
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+#[utoipa::path(
+    get,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/messages",
+    tag = "messages",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        SessionMessagesQuery,
+    ),
+    responses(
+        (status = 200, description = "Session-wide history in store-arrival order, newest first, with cursor pagination", body = SessionMessagesResponse),
+        (status = 404, description = "Session not found"),
+        (status = 503, description = "Not connected")
+    )
+)]
+pub async fn list_session_messages(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Query(q): Query<SessionMessagesQuery>,
+) -> Result<Json<SessionMessagesResponse>, ApiError> {
+    let runtime = state
+        .get_session(&session_id)
+        .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
+    let store = runtime.get_chat_store().ok_or(ApiError::NotConnected)?;
+
+    let limit = q.limit.unwrap_or(20).clamp(1, 200);
+    let after = q.after.map(|seq| ArrivalCursor { seq });
+    let page = store
+        .messages_by_arrival(after, limit)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    let next_cursor = if page.len() as i64 == limit {
+        page.last().map(|m| m.seq)
+    } else {
+        None
+    };
+
+    let mut push_names: std::collections::HashMap<String, Option<String>> =
+        std::collections::HashMap::new();
+    let mut messages = Vec::with_capacity(page.len());
+    for m in &page {
+        let sender = m.sender_jid.to_string();
+        let push_name = if m.from_me {
+            None
+        } else {
+            match push_names.get(&sender) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let name = store
+                        .contact(&m.sender_jid)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|c| c.display_name().map(|s| s.to_string()));
+                    push_names.insert(sender.clone(), name.clone());
+                    name
+                }
+            }
+        };
+        messages.push(MessageHit {
+            id: m.seq,
+            message_id: m.id.clone(),
+            session_id: session_id.clone(),
+            chat_jid: m.chat_jid.to_string(),
+            sender_jid: sender,
+            direction: if m.from_me { "out" } else { "in" }.to_string(),
+            msg_type: message_kind_slug(&m.kind),
+            body: m.text.clone(),
+            snippet: None,
+            msg_timestamp: m.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+            push_name,
+            media: m
+                .message
+                .as_deref()
+                .and_then(crate::handlers::sessions::extract_media_pointer)
+                .and_then(|p| media_pointer_to_model(&p)),
+        });
+    }
+
+    Ok(Json(SessionMessagesResponse {
+        count: messages.len(),
+        messages,
+        next_cursor,
+    }))
+}
+
 fn media_pointer_to_model(m: &MediaPointer) -> Option<MessageMedia> {
     let media_type = match m.media_type.as_str() {
         "image" => MediaType::Image,
@@ -267,5 +391,24 @@ fn rows_to_response(rows: Vec<MessageRow>) -> MessageSearchResponse {
     MessageSearchResponse {
         count: messages.len(),
         messages,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_kind_slug_matches_gateway_slugs() {
+        assert_eq!(message_kind_slug(&MessageKind::Text), "text");
+        assert_eq!(message_kind_slug(&MessageKind::Image), "image");
+        assert_eq!(message_kind_slug(&MessageKind::VoiceNote), "ptt");
+        assert_eq!(message_kind_slug(&MessageKind::Document), "document");
+        assert_eq!(message_kind_slug(&MessageKind::Sticker), "sticker");
+        assert_eq!(
+            message_kind_slug(&MessageKind::Other("protocol".to_string())),
+            "protocol"
+        );
+        assert_eq!(message_kind_slug(&MessageKind::Unknown), "unknown");
     }
 }

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -268,7 +268,7 @@ pub async fn get_session_status(
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
 
-    let (status, is_logged_in, socket_alive, pair) =
+    let (status, is_logged_in, socket_alive, paused, pair) =
         if let Some(runtime) = state.get_session(&session_id) {
             let ps = runtime.get_pair_state();
             let pair = crate::models::sessions::PairStatus {
@@ -279,8 +279,9 @@ pub async fn get_session_status(
                 attempts: ps.attempts,
             };
             let socket_alive = runtime.socket_alive();
+            let paused = runtime.get_client().map(|c| c.is_paused()).unwrap_or(false);
             if runtime.is_alive() {
-                (SessionStatus::LoggedIn, true, socket_alive, pair)
+                (SessionStatus::LoggedIn, true, socket_alive, paused, pair)
             } else {
                 let s = runtime.get_status();
                 let (status, is_logged_in) = if s == SessionStatus::LoggedIn {
@@ -288,12 +289,13 @@ pub async fn get_session_status(
                 } else {
                     (s, false)
                 };
-                (status, is_logged_in, socket_alive, pair)
+                (status, is_logged_in, socket_alive, paused, pair)
             }
         } else {
             (
                 session.status,
                 session.is_logged_in,
+                false,
                 false,
                 crate::models::sessions::PairStatus::default(),
             )
@@ -303,6 +305,7 @@ pub async fn get_session_status(
         status,
         is_logged_in,
         socket_alive,
+        paused,
         phone_number: session.phone_number,
         push_name: session.push_name,
         pair,
@@ -1137,6 +1140,7 @@ async fn connect_client(
     let backend = SqliteStore::new(&db_path)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let chat_store_backend = backend.clone();
 
     let transport_factory = TokioWebSocketTransportFactory::new();
     let http_client = crate::net::build_http_client();
@@ -1178,6 +1182,16 @@ async fn connect_client(
             std::sync::atomic::Ordering::Relaxed,
         );
         c.set_skip_history_sync(runtime.skip_history_sync());
+        match whatsapp_rust_chat_store::ChatStore::new(&chat_store_backend).await {
+            Ok(store) => {
+                let subscription = c.subscribe_handler(store.handler());
+                runtime.set_chat_store(store, subscription);
+            }
+            Err(e) => {
+                tracing::warn!("chat store unavailable for session {}: {}", session_id, e);
+            }
+        }
+        runtime.set_enc_decrypt_failed_lease(c.acquire_enc_decrypt_failed_forwarding());
         runtime.set_client(Some(c));
         runtime.set_status(SessionStatus::WaitingForQr);
     }
@@ -1227,6 +1241,7 @@ async fn connect_client_with_pair_code(
     let backend = SqliteStore::new(&db_path)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let chat_store_backend = backend.clone();
 
     let transport_factory = TokioWebSocketTransportFactory::new();
     let http_client = crate::net::build_http_client();
@@ -1276,6 +1291,16 @@ async fn connect_client_with_pair_code(
             std::sync::atomic::Ordering::Relaxed,
         );
         c.set_skip_history_sync(runtime.skip_history_sync());
+        match whatsapp_rust_chat_store::ChatStore::new(&chat_store_backend).await {
+            Ok(store) => {
+                let subscription = c.subscribe_handler(store.handler());
+                runtime.set_chat_store(store, subscription);
+            }
+            Err(e) => {
+                tracing::warn!("chat store unavailable for session {}: {}", session_id, e);
+            }
+        }
+        runtime.set_enc_decrypt_failed_lease(c.acquire_enc_decrypt_failed_forwarding());
         runtime.set_client(Some(c));
     }
 
@@ -1559,6 +1584,9 @@ fn get_event_type(event: &wacore::types::events::Event) -> String {
         Event::ClientOutdated(_) => "client_outdated".to_string(),
         Event::OfflineSyncPreview(_) => "offline_sync_preview".to_string(),
         Event::OfflineSyncCompleted(_) => "offline_sync_completed".to_string(),
+        Event::CallLogSync(_) => "call_log_sync".to_string(),
+        Event::StreamError(_) => "stream_error".to_string(),
+        Event::EncDecryptFailed(_) => "enc_decrypt_failed".to_string(),
         _ => "unknown".to_string(),
     }
 }
@@ -2130,6 +2158,31 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
                 "info": format!("{:?}", completed),
             })
         }
+        Event::CallLogSync(sync) => {
+            serde_json::json!({
+                "call_creator_jid": sync.call_creator_jid.to_string(),
+                "call_id": sync.call_id,
+                "from_me": sync.from_me,
+                "timestamp": sync.timestamp.timestamp(),
+                "from_full_sync": sync.from_full_sync,
+                "record": format!("{:?}", sync.record),
+            })
+        }
+        Event::StreamError(err) => {
+            serde_json::json!({
+                "code": err.code,
+            })
+        }
+        Event::EncDecryptFailed(failed) => {
+            serde_json::json!({
+                "chat": failed.info.source.chat.to_string(),
+                "sender": failed.info.source.sender.to_string(),
+                "message_id": failed.info.id,
+                "enc_index": failed.enc_index,
+                "enc_type": failed.enc_type,
+                "reason": format!("{:?}", failed.reason),
+            })
+        }
         _ => serde_json::json!({}),
     };
 
@@ -2144,6 +2197,83 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn new_event_variants_map_to_their_webhook_names() {
+        use wacore::types::events::{CallLogSync, EncDecryptFailed, Event, StreamError};
+
+        let stream_error =
+            Event::StreamError(StreamError::builder().code("429".to_string()).build());
+        assert_eq!(get_event_type(&stream_error), "stream_error");
+
+        let call_log = Event::CallLogSync(
+            CallLogSync::builder()
+                .call_creator_jid("12345@s.whatsapp.net".parse().unwrap())
+                .call_id("call-1".to_string())
+                .from_me(true)
+                .timestamp(chrono::Utc::now())
+                .record(Box::new(waproto::whatsapp::CallLogRecord::default()))
+                .from_full_sync(false)
+                .build(),
+        );
+        assert_eq!(get_event_type(&call_log), "call_log_sync");
+
+        let enc_failed = Event::EncDecryptFailed(
+            EncDecryptFailed::builder()
+                .info(std::sync::Arc::new(
+                    wacore::types::message::MessageInfo::default(),
+                ))
+                .enc_index(1)
+                .enc_type(std::borrow::Cow::Borrowed("skmsg"))
+                .reason(wacore::types::events::EncDecryptFailureReason::NoSession)
+                .build(),
+        );
+        assert_eq!(get_event_type(&enc_failed), "enc_decrypt_failed");
+    }
+
+    #[test]
+    fn new_event_variants_serialize_with_event_name_and_data() {
+        use wacore::types::events::{CallLogSync, EncDecryptFailed, Event, StreamError};
+
+        let stream_error =
+            Event::StreamError(StreamError::builder().code("429".to_string()).build());
+        let json = event_to_json(&stream_error, "sess");
+        assert_eq!(json["event"], "stream_error");
+        assert_eq!(json["session_id"], "sess");
+        assert_eq!(json["data"]["code"], "429");
+
+        let call_log = Event::CallLogSync(
+            CallLogSync::builder()
+                .call_creator_jid("12345@s.whatsapp.net".parse().unwrap())
+                .call_id("call-1".to_string())
+                .from_me(true)
+                .timestamp(chrono::Utc::now())
+                .record(Box::new(waproto::whatsapp::CallLogRecord::default()))
+                .from_full_sync(true)
+                .build(),
+        );
+        let json = event_to_json(&call_log, "sess");
+        assert_eq!(json["event"], "call_log_sync");
+        assert_eq!(json["data"]["call_id"], "call-1");
+        assert_eq!(json["data"]["from_me"], true);
+        assert_eq!(json["data"]["from_full_sync"], true);
+
+        let enc_failed = Event::EncDecryptFailed(
+            EncDecryptFailed::builder()
+                .info(std::sync::Arc::new(
+                    wacore::types::message::MessageInfo::default(),
+                ))
+                .enc_index(2)
+                .enc_type(std::borrow::Cow::Borrowed("pkmsg"))
+                .reason(wacore::types::events::EncDecryptFailureReason::BadMac)
+                .build(),
+        );
+        let json = event_to_json(&enc_failed, "sess");
+        assert_eq!(json["event"], "enc_decrypt_failed");
+        assert_eq!(json["data"]["enc_index"], 2);
+        assert_eq!(json["data"]["enc_type"], "pkmsg");
+        assert_eq!(json["data"]["reason"], "BadMac");
+    }
 
     #[test]
     fn zip_round_trips_nested_directory() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,9 @@ use state::AppState;
         handlers::operations::get_auto_reconnect,
         handlers::operations::set_history_sync,
         handlers::operations::get_history_sync,
+        handlers::operations::pause_session,
+        handlers::operations::resume_session,
+        handlers::operations::appstate_resync,
 
         handlers::webhooks::list_webhooks,
         handlers::webhooks::register_webhook,
@@ -247,6 +250,7 @@ use state::AppState;
         handlers::search::search_session_messages,
         handlers::search::search_all_messages,
         handlers::search::list_chat_messages,
+        handlers::search::list_session_messages,
 
         handlers::tokens::mint_token,
         handlers::tokens::list_tokens,

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -118,6 +118,33 @@ pub struct ChatMessagesQuery {
     pub offset: Option<i64>,
 }
 
+/// Query params for `GET /api/v1/sessions/{session_id}/messages`.
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
+pub struct SessionMessagesQuery {
+    /// Keyset cursor: the `seq` of the last message on the previous page,
+    /// taken verbatim from `next_cursor`. Omit for the newest page.
+    pub after: Option<i64>,
+
+    /// Page size (default 20, max 200).
+    pub limit: Option<i64>,
+}
+
+/// Session-wide message page in store-arrival order (newest first),
+/// backed by the upstream chat store rather than the search index.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SessionMessagesResponse {
+    pub messages: Vec<MessageHit>,
+
+    /// Messages in THIS page.
+    #[schema(example = 20)]
+    pub count: usize,
+
+    /// Pass as `after` to fetch the next (older) page. Null on a short
+    /// page, which means the end of the stored history.
+    #[schema(example = 421)]
+    pub next_cursor: Option<i64>,
+}
+
 /// Query params for the fleet-wide `GET /api/v1/messages/search`.
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
 pub struct MessageFleetSearchQuery {

--- a/src/models/sessions.rs
+++ b/src/models/sessions.rs
@@ -217,6 +217,10 @@ pub struct SessionStatusResponse {
     /// dead socket ("limbo"), and a live socket can precede login
     /// during QR/pair flows.
     pub socket_alive: bool,
+    /// Whether the session is paused (`POST /sessions/{id}/pause`): the
+    /// client deliberately keeps no connection open until resumed.
+    /// `false` when there is no live client in this process.
+    pub paused: bool,
     /// Phone number if available
     pub phone_number: Option<String>,
     /// Display name if available

--- a/src/models/webhooks.rs
+++ b/src/models/webhooks.rs
@@ -78,6 +78,20 @@ pub enum WebhookEvent {
     BlastProgress,
 
     BlastCompleted,
+
+    /// A call-history record synced from the primary device
+    /// (upstream `Event::CallLogSync`).
+    CallLogSync,
+
+    /// A server-side stream error stanza (e.g. a 429 rate limit), surfaced
+    /// as upstream `Event::StreamError`.
+    StreamError,
+
+    /// An inbound `<enc>` payload that produced no plaintext, with the
+    /// reason. Upstream only emits this while the gateway holds the
+    /// enc-decrypt-failed forwarding lease, which it acquires for every
+    /// connected client.
+    EncDecryptFailed,
 }
 
 impl WebhookEvent {
@@ -113,6 +127,9 @@ impl WebhookEvent {
             WebhookEvent::ScheduledFailed => event == "scheduled_failed",
             WebhookEvent::BlastProgress => event == "blast_progress",
             WebhookEvent::BlastCompleted => event == "blast_completed",
+            WebhookEvent::CallLogSync => event == "call_log_sync",
+            WebhookEvent::StreamError => event == "stream_error",
+            WebhookEvent::EncDecryptFailed => event == "enc_decrypt_failed",
         }
     }
 
@@ -148,6 +165,9 @@ impl WebhookEvent {
             WebhookEvent::ScheduledFailed => "scheduled_failed",
             WebhookEvent::BlastProgress => "blast_progress",
             WebhookEvent::BlastCompleted => "blast_completed",
+            WebhookEvent::CallLogSync => "call_log_sync",
+            WebhookEvent::StreamError => "stream_error",
+            WebhookEvent::EncDecryptFailed => "enc_decrypt_failed",
         }
     }
 
@@ -186,6 +206,9 @@ impl WebhookEvent {
             "scheduled_failed" => Some(WebhookEvent::ScheduledFailed),
             "blast_progress" => Some(WebhookEvent::BlastProgress),
             "blast_completed" => Some(WebhookEvent::BlastCompleted),
+            "call_log_sync" => Some(WebhookEvent::CallLogSync),
+            "stream_error" => Some(WebhookEvent::StreamError),
+            "enc_decrypt_failed" => Some(WebhookEvent::EncDecryptFailed),
             _ => None,
         }
     }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -274,6 +274,10 @@ fn session_routes() -> Router<AppState> {
             get(handlers::search::list_chat_messages),
         )
         .route(
+            "/{session_id}/messages",
+            get(handlers::search::list_session_messages),
+        )
+        .route(
             "/{session_id}/messages/newsletter-forward",
             post(handlers::messages::send_newsletter_forward),
         )
@@ -529,6 +533,18 @@ fn session_routes() -> Router<AppState> {
         .route(
             "/{session_id}/history-sync",
             get(handlers::operations::get_history_sync).put(handlers::operations::set_history_sync),
+        )
+        .route(
+            "/{session_id}/pause",
+            post(handlers::operations::pause_session),
+        )
+        .route(
+            "/{session_id}/resume",
+            post(handlers::operations::resume_session),
+        )
+        .route(
+            "/{session_id}/appstate/resync",
+            post(handlers::operations::appstate_resync),
         )
         .route(
             "/{session_id}/media/upload",

--- a/src/state.rs
+++ b/src/state.rs
@@ -214,6 +214,23 @@ pub struct SessionState {
     /// skip-history-sync flag, stored gateway-side and applied to every
     /// newly built client.
     pub skip_history_sync_pref: AtomicBool,
+
+    /// Held while a client is installed so the client keeps emitting
+    /// `Event::EncDecryptFailed` (upstream gates the event on at least one
+    /// lease being held; dropping the last lease silences it). Acquired in
+    /// `connect_client` alongside `set_client` and dropped with the client.
+    pub enc_decrypt_failed_lease: RwLock<Option<whatsapp_rust::EncDecryptFailedLease>>,
+
+    /// Session-wide message history materialized into the session's
+    /// whatsapp.db by the upstream chat store. Backs
+    /// `GET /sessions/{id}/messages`. Installed alongside the client;
+    /// `None` when there is no live client (or the store failed to open,
+    /// which is logged and non-fatal).
+    pub chat_store: RwLock<Option<Arc<whatsapp_rust_chat_store::ChatStore>>>,
+
+    /// Keeps the chat store's event handler subscribed; dropping it
+    /// unsubscribes. Always mirrors the `chat_store` slot.
+    pub chat_store_subscription: RwLock<Option<wacore::types::events::Subscription>>,
 }
 
 /// Snapshot of the latest pair attempt for a session. Lives entirely in
@@ -244,6 +261,9 @@ impl SessionState {
             lock_strikes: RwLock::new(0),
             auto_reconnect_pref: AtomicBool::new(true),
             skip_history_sync_pref: AtomicBool::new(false),
+            enc_decrypt_failed_lease: RwLock::new(None),
+            chat_store: RwLock::new(None),
+            chat_store_subscription: RwLock::new(None),
         }
     }
 
@@ -382,7 +402,34 @@ impl SessionState {
     }
 
     pub fn set_client(&self, client: Option<Arc<Client>>) {
+        if client.is_none() {
+            *self.enc_decrypt_failed_lease.write() = None;
+            *self.chat_store.write() = None;
+            *self.chat_store_subscription.write() = None;
+        }
         *self.client.write() = client;
+    }
+
+    /// Install the [`whatsapp_rust::EncDecryptFailedLease`] for the current
+    /// client; call right after building a client, before [`Self::set_client`].
+    pub fn set_enc_decrypt_failed_lease(&self, lease: whatsapp_rust::EncDecryptFailedLease) {
+        *self.enc_decrypt_failed_lease.write() = Some(lease);
+    }
+
+    /// Install the chat store and the subscription keeping its event
+    /// handler registered; call right after building a client, before
+    /// [`Self::set_client`].
+    pub fn set_chat_store(
+        &self,
+        store: Arc<whatsapp_rust_chat_store::ChatStore>,
+        subscription: wacore::types::events::Subscription,
+    ) {
+        *self.chat_store.write() = Some(store);
+        *self.chat_store_subscription.write() = Some(subscription);
+    }
+
+    pub fn get_chat_store(&self) -> Option<Arc<whatsapp_rust_chat_store::ChatStore>> {
+        self.chat_store.read().clone()
     }
 
     pub fn get_qr_codes(&self) -> Vec<String> {

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -484,3 +484,183 @@ async fn create_with_reuse_on_unknown_id_creates_normally() {
         Some("s-fresh")
     );
 }
+
+/// `POST /sessions/{id}/pause` and `/resume` drive the upstream
+/// `Client::pause`/`resume`, so they need an installed client instance —
+/// a session that exists only as a DB row gets 503, not 404/200.
+#[tokio::test]
+async fn pause_resume_require_an_installed_client() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-pause"}),
+        ),
+    )
+    .await;
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-pause/pause",
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-pause/resume",
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/ghost/pause",
+            Some(TEST_TOKEN),
+            json!({}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// `/status` exposes the upstream `Client::is_paused` state; with no
+/// client installed it must report `false` rather than omit the field.
+#[tokio::test]
+async fn status_reports_paused_false_without_client() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-paused-f"}),
+        ),
+    )
+    .await;
+    let (status, body) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-paused-f/status", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.get("paused").and_then(|v| v.as_bool()), Some(false));
+}
+
+/// `POST /sessions/{id}/appstate/resync` validates collection names and
+/// the mode before ever touching the client, so bad input is a 400 even
+/// with no session connected.
+#[tokio::test]
+async fn appstate_resync_validates_request_body() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-resync"}),
+        ),
+    )
+    .await;
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-resync/appstate/resync",
+            Some(TEST_TOKEN),
+            json!({"collections": ["bogus_collection"]}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-resync/appstate/resync",
+            Some(TEST_TOKEN),
+            json!({"collections": ["regular"], "mode": "full"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-resync/appstate/resync",
+            Some(TEST_TOKEN),
+            json!({"collections": []}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/s-resync/appstate/resync",
+            Some(TEST_TOKEN),
+            json!({"collections": ["critical_block", "regular"], "mode": "snapshot"}),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a valid request with no live client reaches the 503 gate"
+    );
+}
+
+/// `GET /sessions/{id}/messages` pages the upstream chat store, which only
+/// exists while a client is installed — a session with a runtime but no
+/// connected client answers 503, an unknown session 404.
+#[tokio::test]
+async fn list_session_messages_requires_runtime() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-arrival"}),
+        ),
+    )
+    .await;
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/s-arrival/messages", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let (status, _) = call(
+        &h.app,
+        req_get("/api/v1/sessions/ghost/messages", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/tests/webhooks.rs
+++ b/tests/webhooks.rs
@@ -177,3 +177,37 @@ async fn dlq_replay_missing_entry_returns_404() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+/// The upstream-sync event variants (`call_log_sync`, `stream_error`,
+/// `enc_decrypt_failed`) are valid `WebhookEvent` values end to end:
+/// accepted at registration and echoed back by the list endpoint.
+#[tokio::test]
+async fn register_webhook_accepts_upstream_sync_events() {
+    let h = Harness::new().await;
+    seed_session(&h, "wh-sync-01").await;
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions/wh-sync-01/webhooks",
+            Some(TEST_TOKEN),
+            json!({
+                "url": "https://example.com/hook",
+                "events": ["call_log_sync", "stream_error", "enc_decrypt_failed"]
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let events: Vec<&str> = body
+        .get("events")
+        .and_then(|v| v.as_array())
+        .expect("events array")
+        .iter()
+        .filter_map(|e| e.as_str())
+        .collect();
+    assert_eq!(
+        events,
+        vec!["call_log_sync", "stream_error", "enc_decrypt_failed"]
+    );
+}


### PR DESCRIPTION
## Summary

Bumps the vendored whatsapp-rust stack `5e084b9` → `8cea605f` (25 upstream commits) and wires the new upstream capabilities into the gateway. Stacks on top of PR #74 (`dev`).

**New endpoints**
- `POST /api/v1/sessions/{id}/pause` + `/resume` — take a session offline/online on demand (upstream `Client::pause/resume/is_paused`); `paused` added to `GET /sessions/{id}/status`
- `POST /api/v1/sessions/{id}/appstate/resync` — body `{collections: ["critical_block", ...], mode: "incremental"|"snapshot"}`; validated 400s, 503 without live client
- `GET /api/v1/sessions/{id}/messages?after=<seq>&limit=<n>` — session-wide arrival-ordered history with keyset cursor (`next_cursor`), backed by the new upstream `whatsapp-rust-chat-store` crate

**New webhook/NATS events**
- `call_log_sync` (app-state call_log mutations)
- `stream_error` (e.g. 429 rate-limit surfaced as an event)
- `enc_decrypt_failed` (which <enc> failed + why; forwarded via the upstream lease acquired on connect)

**Free with the bump**: group sender-key redistribution fix, shared SQLite pool across devices, socket buffer memory fixes, reconnect-announcement correctness fixes, protocol regen 2.3000.1044659339.

## Verification
- `cargo fmt` / `clippy --all-targets -D warnings` clean
- `cargo test`: **95 passed, 0 failed** (11 new: event arms, resync validation, pause/resume + paging contract tests)
- CHANGELOG updated under `[Unreleased]`

Note: `next_cursor` is a store-local `seq` — non-durable across restarts/VACUUM (upstream-documented), fine for paging.