### PR TITLE
fix: migrate SQLite message media columns

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,4 +1,5 @@
 use crate::db::session::{sqlite_blocking, DbPool};
+use std::collections::HashSet;
 
 pub async fn init_schema(pool: &DbPool) -> anyhow::Result<()> {
     match pool {
@@ -11,9 +12,9 @@ pub async fn init_schema(pool: &DbPool) -> anyhow::Result<()> {
 /// `CREATE TABLE IF NOT EXISTS` is a no-op on a table that already
 /// exists, so columns added to `messages` after a DB was first
 /// created (the media pointer + push-name join fields) need an
-/// explicit `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` per column,
-/// each run independently so an already-present column never aborts
-/// the rest. Mirrors the tolerant migration list [`init_mysql`] runs.
+/// explicit `ALTER TABLE ... ADD COLUMN` for each missing column. SQLite
+/// doesn't support `ADD COLUMN IF NOT EXISTS`, so inspect `table_info`
+/// first instead of swallowing a syntax error on every startup.
 async fn init_sqlite(pool: &crate::db::session::SqlitePool) -> anyhow::Result<()> {
     use crate::db::sqlite_raw;
     sqlite_blocking(pool, |conn| {
@@ -158,16 +159,29 @@ async fn init_sqlite(pool: &crate::db::session::SqlitePool) -> anyhow::Result<()
              ); \
              CREATE INDEX IF NOT EXISTS idx_token_sessions_session ON token_sessions(session_id);",
         )?;
-        for sql in [
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS media_key TEXT",
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_sha256 TEXT",
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_enc_sha256 TEXT",
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS direct_path TEXT",
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS file_length INTEGER",
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS media_type TEXT",
-            "ALTER TABLE messages ADD COLUMN IF NOT EXISTS mimetype TEXT",
+        let existing_columns: HashSet<String> = sqlite_raw::query(
+            conn,
+            "PRAGMA table_info(messages)",
+            &[],
+            |row| row.get_string(1).unwrap_or_default(),
+        )?
+        .into_iter()
+        .collect();
+        for (column, definition) in [
+            ("media_key", "TEXT"),
+            ("file_sha256", "TEXT"),
+            ("file_enc_sha256", "TEXT"),
+            ("direct_path", "TEXT"),
+            ("file_length", "INTEGER"),
+            ("media_type", "TEXT"),
+            ("mimetype", "TEXT"),
         ] {
-            let _ = sqlite_raw::exec_batch(conn, sql);
+            if !existing_columns.contains(column) {
+                sqlite_raw::exec_batch(
+                    conn,
+                    &format!("ALTER TABLE messages ADD COLUMN {column} {definition}"),
+                )?;
+            }
         }
         if let Err(e) = sqlite_raw::exec_batch(
             conn,

--- a/tests/schema_migration.rs
+++ b/tests/schema_migration.rs
@@ -1,0 +1,90 @@
+use std::collections::HashSet;
+
+use waxum::db::{
+    schema,
+    session::DbPool,
+    sqlite_raw::{self, Value},
+};
+
+#[tokio::test]
+async fn sqlite_upgrade_adds_message_media_columns() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let db_path = dir.path().join("waxum.db");
+    let handle = sqlite_raw::open(db_path.to_str().expect("utf-8 path")).expect("open sqlite");
+
+    {
+        let conn = handle.lock();
+        sqlite_raw::exec_batch(
+            &conn,
+            "CREATE TABLE messages (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                message_id TEXT NOT NULL, \
+                session_id TEXT NOT NULL, \
+                chat_jid TEXT NOT NULL, \
+                sender_jid TEXT NOT NULL, \
+                direction TEXT NOT NULL, \
+                msg_type TEXT NOT NULL, \
+                body TEXT, \
+                msg_timestamp TEXT NOT NULL, \
+                created_at TEXT NOT NULL, \
+                UNIQUE (session_id, message_id)\
+            );",
+        )
+        .expect("create legacy messages table");
+    }
+
+    let pool = DbPool::SQLite(handle.clone());
+    schema::init_schema(&pool).await.expect("migrate schema");
+    schema::init_schema(&pool).await.expect("repeat migration");
+
+    let conn = handle.lock();
+    let columns: HashSet<String> =
+        sqlite_raw::query(&conn, "PRAGMA table_info(messages)", &[], |row| {
+            row.get_string(1).expect("column name")
+        })
+        .expect("read columns")
+        .into_iter()
+        .collect();
+
+    for expected in [
+        "media_key",
+        "file_sha256",
+        "file_enc_sha256",
+        "direct_path",
+        "file_length",
+        "media_type",
+        "mimetype",
+    ] {
+        assert!(
+            columns.contains(expected),
+            "missing migrated column {expected}"
+        );
+    }
+
+    sqlite_raw::execute(
+        &conn,
+        "INSERT INTO messages (message_id, session_id, chat_jid, sender_jid, direction, \
+         msg_type, body, msg_timestamp, created_at, media_key, file_sha256, file_enc_sha256, \
+         direct_path, file_length, media_type, mimetype) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        &[
+            Value::Text("msg-1".into()),
+            Value::Text("session-1".into()),
+            Value::Text("chat@s.whatsapp.net".into()),
+            Value::Text("sender@s.whatsapp.net".into()),
+            Value::Text("in".into()),
+            Value::Text("image".into()),
+            Value::Text("caption".into()),
+            Value::Text("2026-08-17 00:00:00".into()),
+            Value::Text("2026-08-17 00:00:00".into()),
+            Value::Text("key".into()),
+            Value::Text("sha".into()),
+            Value::Text("enc-sha".into()),
+            Value::Text("/media/path".into()),
+            Value::Int(42),
+            Value::Text("image".into()),
+            Value::Text("image/jpeg".into()),
+        ],
+    )
+    .expect("insert message with migrated media columns");
+}


### PR DESCRIPTION
## Summary

- detect existing SQLite message columns via `PRAGMA table_info`
- add missing media pointer columns during startup
- fail visibly when a required migration cannot be applied
- cover legacy-schema upgrade, idempotency, and media-history insertion

## Root cause

SQLite does not support `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. The previous startup migration used that syntax and swallowed each error, leaving upgraded databases without the media columns.

Closes #78

## Validation

- `cargo test`
- pre-push `cargo fmt --check`
- pre-push `cargo clippy --all-targets -- -D warnings`
- pre-push `cargo build`