### PR TITLE
whatsapp-rust 0.7.0 bump: video orientation, reachability, unkeyed-device metrics, one-shot pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to **waxum** will be documented in this file.
 
 ## [Unreleased]
 
+### Added — `GET /sessions/{id}/contacts/{jid}/lid`
+
+On-demand LID↔phone-number resolution, backed by `Client::get_lid_pn_entry`
+— the same lookup already used internally to populate `from_phone` on
+incoming-message webhooks (`resolve_sender_phone`), now exposed directly so
+a caller holding a bare `@lid` sender JID (e.g. from stored message history)
+can resolve it without waiting for a fresh webhook. Answers from
+whatsapp-rust's own cache/DB mapping, no live network round trip; 404 if the
+pair hasn't been learned yet, 503 if the session has no connected client.
+
 ### Changed
 
 Bumped the vendored `whatsapp-rust` (and `wacore`/`wacore-binary`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to **waxum** will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — vendored whatsapp-rust bumped to `1489b7d` (upstream `0.7.0`)
+
+47 upstream commits since the last bump. Notable: the voip relay media
+stack moved to the sans-io `rtc-*` crates (transparent — nothing in
+waxum's calls code touched the old `webrtc-*` types directly); the
+peer `push_name` event (`Event::PushNameUpdate`) was formally retired
+upstream ("nothing constructs this and nothing dispatches the variant
+it fills" — dead code even before this bump) and its 3 call sites here
+removed, with no behavior change since it never actually fired; and
+the incoming-message envelope `type` field is now a typed
+`StanzaMessageType` instead of a bare string, which — because it
+derives the same `Serialize` waxum's webhook payload already relies
+on — keeps working with no code change on this side.
+
+New capabilities wired in from the bump:
+
+- **`POST /sessions/{id}/calls/video-orientation`** — announce a quarter-turn
+  camera rotation to the peer mid-call, via the new
+  `CallHandle::set_video_orientation`.
+- **`reachability` field on `GET /sessions/{id}/status`** — the client's own
+  `reachability()` verdict (`reachable` / `reconnecting` / `paused` /
+  `unsupervised` / `finished`), finer-grained than the existing
+  `status`/`socket_alive` pair. `null` when there's no live client at all.
+- **`waxum_session_devices_unkeyed_total{session_id,reason}`** on `/metrics`
+  — per-session, per-reason gauge (`no_bundle`/`session_setup`/`rejected`/
+  `fetch_failed`/`encrypt`) read from the client's own send-observability
+  counters, so a silently-degraded send (message "sent" but never reached
+  some devices) is now visible instead of invisible until a user complains.
+
+### Added — `GET /sessions/{id}/connect/wait`
+
+One-shot pairing flow as a single SSE stream: creates the session if it
+doesn't exist, connects it if it isn't already connecting/connected, and
+streams `qr_code` → `pair_code` → `connected` → `ready` (or `error` /
+`timeout`) — so a caller doesn't have to orchestrate `POST /sessions` +
+poll `/qr` + poll `/status` + watch webhooks by hand. `ready` fires
+immediately if the session was already logged in when the stream opened;
+otherwise after `connected` if history sync is disabled for the session,
+or after the upstream `offline_sync_completed` event otherwise. Built on
+the per-session `broadcast::Sender<String>` that already mirrored every
+webhook payload (`SessionState::event_tx`) but had no subscriber until now.
+
 ### Added — `GET /sessions/{id}/contacts/{jid}/lid`
 
 On-demand LID↔phone-number resolution, backed by `Client::get_lid_pn_entry`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3175,7 +3175,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3659,7 +3659,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3740,7 +3740,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3761,7 +3761,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4340,7 +4340,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5543,7 +5543,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,20 +52,6 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead 0.5.2",
- "aes 0.8.4",
- "cipher 0.4.4",
- "ctr 0.9.2",
- "ghash 0.5.1",
- "subtle",
-]
-
-[[package]]
-name = "aes-gcm"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
@@ -74,7 +60,7 @@ dependencies = [
  "aes 0.9.2",
  "cipher 0.5.2",
  "ctr 0.10.1",
- "ghash 0.6.0",
+ "ghash",
  "subtle",
 ]
 
@@ -133,21 +119,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -158,10 +135,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -209,7 +214,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "memchr",
@@ -304,7 +309,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -365,16 +370,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -383,10 +388,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bit-vec"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
@@ -423,15 +428,6 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
@@ -455,7 +451,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -500,7 +496,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e6224bc4ee1f189ad257120c156fb05f95b826f5369d620b24984476c200a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "foldhash 0.1.5",
  "hashbrown 0.15.5",
@@ -557,6 +553,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,15 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher 0.4.4",
 ]
 
 [[package]]
@@ -826,19 +836,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
+name = "crc32c"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "crc-catalog",
+ "rustc_version",
 ]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -906,18 +910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,7 +969,6 @@ dependencies = [
  "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1182,7 +1173,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1295,7 +1300,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1365,20 +1369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,27 +1395,6 @@ name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf 0.12.4",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -1483,16 +1452,6 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -1668,7 +1627,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1714,21 +1672,11 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval 0.6.2",
-]
-
-[[package]]
-name = "ghash"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "polyval 0.7.3",
+ "polyval",
 ]
 
 [[package]]
@@ -1762,17 +1710,6 @@ checksum = "4387e0458389da24c6fe732531e65595c7c4a32b027f98f4789e512e28224465"
 dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1862,15 +1799,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "hkdf"
@@ -1997,7 +1925,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2165,7 +2093,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -2175,7 +2102,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "block-padding 0.4.2",
+ "block-padding",
  "hybrid-array",
 ]
 
@@ -2292,7 +2219,7 @@ version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -2430,6 +2357,16 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -2452,9 +2389,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -2559,6 +2496,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "mysql-common-derive"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2573,7 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34a9141e735d5bb02414a7ac03add09522466d4db65bdd827069f76ae0850e58"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "btoi",
  "byteorder",
@@ -2644,15 +2601,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset",
- "pin-utils",
 ]
 
 [[package]]
@@ -2793,7 +2750,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -2801,12 +2767,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -2827,30 +2787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
 dependencies = [
  "audiopus_sys",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2888,7 +2824,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2995,12 +2931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,25 +2948,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash 0.5.1",
-]
-
-[[package]]
-name = "polyval"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
- "universal-hash 0.6.1",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3051,12 +2969,12 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac 0.13.0",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
  "rand 0.10.2",
  "sha2 0.11.0",
@@ -3111,15 +3029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,6 +3069,26 @@ dependencies = [
  "memchr",
  "parking_lot",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3282,6 +3211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rancor"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,14 +3315,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser 0.18.1",
  "yasna",
 ]
 
@@ -3427,12 +3366,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rend"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3504,16 +3452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,6 +3466,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,6 +3503,91 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtc-crypto"
+version = "0.21.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0f2e4801a79469b8094f715f563d946c76826336f8d9fefb47dc6628524f11"
+dependencies = [
+ "aes 0.8.4",
+ "ccm",
+ "ctr 0.9.2",
+ "hmac 0.12.1",
+ "md-5 0.10.6",
+ "rand 0.10.2",
+ "ring",
+ "sha1 0.10.7",
+ "subtle",
+ "thiserror 2.0.19",
+ "zeroize",
+]
+
+[[package]]
+name = "rtc-datachannel"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374adcfc6f138839109d84c521ccedae9410b11f62c1ae577cb786ed91494f50"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-sctp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-dtls"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3baf3ee5b4d481d57fdee828ed4abd281ba45ad98594502cd4e866d14316b48f"
+dependencies = [
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "der-parser 9.0.0",
+ "log",
+ "pem",
+ "rcgen",
+ "rkyv",
+ "rtc-crypto",
+ "rtc-shared",
+ "rustls",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "rtc-sctp"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db38ed06af7bea634b210c3e8cf0e78e3bb36669e120968f5961a3c12a209b67"
+dependencies = [
+ "bytes",
+ "crc32c",
+ "log",
+ "rand 0.10.2",
+ "rtc-shared",
+ "rustc-hash",
+ "slab",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtc-shared"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108063844e58fa8470139c2d6bea3a28362e07d43194acef7e0d57d829d27cd6"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes",
+ "nix",
+ "rand 0.10.2",
+ "serde",
+ "substring",
+ "thiserror 2.0.19",
+ "url",
+ "winapi",
 ]
 
 [[package]]
@@ -3758,7 +3811,7 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce58958ac8d7b05b9f146337b88231db2ca95ab7637cf44f318c2e9e4855ff"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-io",
@@ -3768,7 +3821,7 @@ dependencies = [
  "http",
  "http-body-util",
  "httpdate",
- "md-5",
+ "md-5 0.11.0",
  "quick-xml",
  "reqx",
  "serde",
@@ -3785,6 +3838,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "sansio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
 
 [[package]]
 name = "saturating"
@@ -3815,20 +3874,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -4229,6 +4274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,7 +4564,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -4531,7 +4585,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -4810,16 +4864,6 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "universal-hash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
@@ -4840,7 +4884,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cookie_store",
  "flate2",
  "log",
@@ -4861,7 +4905,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -4922,7 +4966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -4967,15 +5011,15 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "wacore"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "aes 0.9.2",
- "aes-gcm 0.11.0",
+ "aes-gcm",
  "anyhow",
  "async-channel",
  "async-lock",
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "bon",
  "buffa",
  "buffa-build",
@@ -4987,7 +5031,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "itoa",
  "log",
@@ -5017,12 +5061,12 @@ dependencies = [
 [[package]]
 name = "wacore-appstate"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "anyhow",
  "buffa",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "log",
  "serde",
@@ -5038,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "wacore-binary"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "bytes",
  "compact_str",
@@ -5055,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "wacore-derive"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5065,20 +5109,20 @@ dependencies = [
 [[package]]
 name = "wacore-libsignal"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "aes 0.9.2",
  "async-lock",
  "async-trait",
  "buffa",
  "bytes",
- "cbc 0.2.1",
+ "cbc",
  "chrono",
  "ctr 0.10.1",
  "curve25519-dalek 5.0.0",
- "ghash 0.6.0",
+ "ghash",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "log",
  "portable-atomic",
@@ -5090,18 +5134,18 @@ dependencies = [
  "thiserror 2.0.19",
  "wacore-derive",
  "waproto",
- "x25519-dalek 3.0.0",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "wacore-noise"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "anyhow",
  "buffa",
  "bytes",
- "hkdf 0.13.0",
+ "hkdf",
  "log",
  "rand 0.10.2",
  "sha2 0.11.0",
@@ -5133,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "waproto"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -5241,7 +5285,7 @@ dependencies = [
  "async-nats",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "dashmap",
@@ -5351,126 +5395,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "webrtc-data"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd470286275809f2fcfcdb1e73ef5f1500be82eff7fe98150ce81b20aad5a2a4"
-dependencies = [
- "bytes",
- "log",
- "portable-atomic",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-sctp",
- "webrtc-util 0.17.2",
-]
-
-[[package]]
-name = "webrtc-dtls"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccbe4d9049390ab52695c3646c1395c877e16c15fb05d3bda8eee0c7351711c"
-dependencies = [
- "aes 0.8.4",
- "aes-gcm 0.10.3",
- "async-trait",
- "bincode",
- "byteorder",
- "cbc 0.1.2",
- "ccm",
- "der-parser",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "log",
- "p256",
- "p384",
- "portable-atomic",
- "rand 0.8.7",
- "rand_core 0.6.4",
- "rcgen",
- "ring",
- "rustls",
- "sec1",
- "serde",
- "sha1 0.10.7",
- "sha2 0.10.9",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util 0.11.0",
- "x25519-dalek 2.0.1",
- "x509-parser",
-]
-
-[[package]]
-name = "webrtc-sctp"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4b637f0d8eb96d900ac0f79b3060ddd21ca88dfefa467e96e67ab0016f2574"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "crc",
- "log",
- "portable-atomic",
- "rand 0.9.5",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util 0.17.2",
-]
-
-[[package]]
-name = "webrtc-util"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
-dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bytes",
- "ipnet",
- "lazy_static",
- "libc",
- "log",
- "nix",
- "portable-atomic",
- "rand 0.8.7",
- "thiserror 1.0.69",
- "tokio",
- "winapi",
-]
-
-[[package]]
-name = "webrtc-util"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1beae0b4f24969741c26ca282a257dc5823bd9cbe608f7e3ca3775102d323ad9"
-dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bytes",
- "ipnet",
- "lazy_static",
- "log",
- "nix",
- "portable-atomic",
- "rand 0.9.5",
- "thiserror 1.0.69",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "whatsapp-rust"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-lock",
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "buffa",
  "bytes",
  "chrono",
@@ -5484,7 +5417,10 @@ dependencies = [
  "opus",
  "portable-atomic",
  "rand 0.10.2",
- "rustls",
+ "rtc-datachannel",
+ "rtc-dtls",
+ "rtc-sctp",
+ "rtc-shared",
  "scopeguard",
  "serde",
  "serde_json",
@@ -5495,11 +5431,6 @@ dependencies = [
  "wacore",
  "wacore-binary",
  "waproto",
- "webrtc-data",
- "webrtc-dtls",
- "webrtc-sctp",
- "webrtc-util 0.11.0",
- "webrtc-util 0.17.2",
  "whatsapp-rust-sqlite-storage",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
@@ -5509,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-chat-store"
 version = "0.1.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "buffa",
  "chrono",
@@ -5528,7 +5459,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-sqlite-storage"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "async-trait",
  "buffa",
@@ -5548,7 +5479,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-tokio-transport"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -5568,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
 version = "0.7.0"
-source = "git+https://github.com/oxidezap/whatsapp-rust?rev=8cea605fa53b5cfb3093a6798d341798184a2928#8cea605fa53b5cfb3093a6798d341798184a2928"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=1489b7da9a6a7e3cadc4337ee46399da7de25915#1489b7da9a6a7e3cadc4337ee46399da7de25915"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5857,18 +5788,6 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "rand_core 0.6.4",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
@@ -5884,23 +5803,42 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
-name = "yasna"
-version = "0.5.2"
+name = "x509-parser"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
+ "asn1-rs 0.7.2",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
  "time",
 ]
 
@@ -5973,20 +5911,6 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ repository = "https://github.com/imtaqin/waxum"
 [dependencies]
 
 rand = "0.8"
-whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928", default-features = true, features = ["voip", "tracing"] }
-wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
-wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
-waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
-whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
-whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
-whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
-whatsapp-rust-chat-store = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "8cea605fa53b5cfb3093a6798d341798184a2928" }
+whatsapp-rust = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915", default-features = true, features = ["voip", "tracing"] }
+wacore = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
+wacore-binary = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
+waproto = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
+whatsapp-rust-sqlite-storage = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
+whatsapp-rust-tokio-transport = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
+whatsapp-rust-chat-store = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "1489b7da9a6a7e3cadc4337ee46399da7de25915" }
 
 # Web framework
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }

--- a/src/handlers/calls.rs
+++ b/src/handlers/calls.rs
@@ -600,6 +600,51 @@ pub async fn terminate_call(
 #[utoipa::path(
     post,
     security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/calls/video-orientation",
+    tag = "calls",
+    params(
+        ("session_id" = String, Path, description = "Session ID")
+    ),
+    request_body = crate::models::calls::SetVideoOrientationRequest,
+    responses(
+        (status = 200, description = "Orientation announced to the peer", body = SuccessResponse),
+        (status = 400, description = "Empty call_id, orientation out of 0-3 range, or call not active"),
+        (status = 404, description = "Session not found"),
+        (status = 503, description = "Not connected")
+    )
+)]
+pub async fn set_call_video_orientation(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Json(request): Json<crate::models::calls::SetVideoOrientationRequest>,
+) -> Result<Json<SuccessResponse>, ApiError> {
+    if request.call_id.is_empty() {
+        return Err(ApiError::BadRequest("call_id is empty".to_string()));
+    }
+    // Not strictly needed to reach the handle (active_calls is keyed by
+    // call_id alone), but keeps this endpoint's auth/connected-session
+    // requirements consistent with every other /calls/* mutation.
+    let _client = get_client(&state, &session_id)?;
+
+    let handle = state
+        .active_calls()
+        .get(&request.call_id)
+        .map(|e| e.value().clone())
+        .ok_or_else(|| ApiError::BadRequest("call_id not found in registry".to_string()))?;
+
+    handle
+        .set_video_orientation(request.orientation)
+        .await
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    Ok(Json(SuccessResponse::with_message(
+        "Video orientation updated",
+    )))
+}
+
+#[utoipa::path(
+    post,
+    security(("bearer_auth" = [])),
     path = "/api/v1/sessions/{session_id}/calls/tts",
     tag = "calls",
     params(

--- a/src/handlers/calls.rs
+++ b/src/handlers/calls.rs
@@ -597,6 +597,10 @@ pub async fn terminate_call(
     Ok(Json(SuccessResponse::with_message("Call terminated")))
 }
 
+/// The `get_client` call below isn't strictly needed to reach the handle
+/// (`active_calls` is keyed by `call_id` alone), but keeps this endpoint's
+/// auth/connected-session requirements consistent with every other
+/// `/calls/*` mutation.
 #[utoipa::path(
     post,
     security(("bearer_auth" = [])),
@@ -621,9 +625,6 @@ pub async fn set_call_video_orientation(
     if request.call_id.is_empty() {
         return Err(ApiError::BadRequest("call_id is empty".to_string()));
     }
-    // Not strictly needed to reach the handle (active_calls is keyed by
-    // call_id alone), but keeps this endpoint's auth/connected-session
-    // requirements consistent with every other /calls/* mutation.
     let _client = get_client(&state, &session_id)?;
 
     let handle = state

--- a/src/handlers/contacts.rs
+++ b/src/handlers/contacts.rs
@@ -316,3 +316,47 @@ async fn do_get_user_info(
     })
     .await
 }
+
+/// Resolve a LID (`@lid`) JID to its phone number, or a phone-number JID to
+/// its LID, via `Client::get_lid_pn_entry`. Answers from the in-memory
+/// cache/DB mapping learned from usync, peer messages, pairing, etc. — no
+/// live network round-trip, so this can return `None` for a pair the
+/// session hasn't observed yet even while connected.
+#[utoipa::path(
+    get,
+    security(("bearer_auth" = [])),
+    path = "/api/v1/sessions/{session_id}/contacts/{jid}/lid",
+    tag = "contacts",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("jid" = String, Path, description = "A `@lid` JID or a phone-number JID (with or without `@s.whatsapp.net`)")
+    ),
+    responses(
+        (status = 200, description = "Mapping found", body = LidPnEntryResponse),
+        (status = 404, description = "No mapping known for this JID"),
+        (status = 503, description = "Session not connected")
+    )
+)]
+pub async fn resolve_lid(
+    State(state): State<AppState>,
+    Path((session_id, jid)): Path<(String, String)>,
+) -> Result<Json<LidPnEntryResponse>, ApiError> {
+    let client = crate::handlers::messages::get_client(&state, &session_id)?;
+    let target = crate::handlers::messages::parse_jid(&jid)?;
+
+    let entry = AssertSend(async move {
+        client
+            .get_lid_pn_entry(&target)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))
+    })
+    .await?
+    .ok_or_else(|| ApiError::ContactNotFound(jid.clone()))?;
+
+    Ok(Json(LidPnEntryResponse {
+        lid: entry.lid.to_string(),
+        phone_number: entry.phone_number.to_string(),
+        created_at: entry.created_at,
+        learning_source: entry.learning_source.to_string(),
+    }))
+}

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -576,10 +576,6 @@ pub async fn connect_and_wait(
                     };
                     let event_name = v.get("event").and_then(|e| e.as_str()).unwrap_or("");
                     match event_name {
-                        // Not collapsed into the match guard (as clippy's
-                        // `collapsible_match` suggests): the guard would move
-                        // `payload` even on a false result, making it
-                        // unavailable to the arms below.
                         #[allow(clippy::collapsible_match)]
                         "qr_code" | "pair_code" => {
                             if tx

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -1,10 +1,12 @@
 use std::time::Duration;
 
 use axum::{
-    extract::{Multipart, Path, State},
+    extract::{Multipart, Path, Query, State},
+    response::sse::{Event as SseEvent, KeepAlive, Sse},
     response::Response as AxumResponse,
     Json,
 };
+use futures::stream::Stream;
 use uuid::Uuid;
 
 use crate::device_props::ResolvedDeviceProps;
@@ -268,7 +270,7 @@ pub async fn get_session_status(
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| ApiError::SessionNotFound(session_id.clone()))?;
 
-    let (status, is_logged_in, socket_alive, paused, pair) =
+    let (status, is_logged_in, socket_alive, paused, pair, reachability) =
         if let Some(runtime) = state.get_session(&session_id) {
             let ps = runtime.get_pair_state();
             let pair = crate::models::sessions::PairStatus {
@@ -279,9 +281,18 @@ pub async fn get_session_status(
                 attempts: ps.attempts,
             };
             let socket_alive = runtime.socket_alive();
-            let paused = runtime.get_client().map(|c| c.is_paused()).unwrap_or(false);
+            let client = runtime.get_client();
+            let paused = client.as_ref().map(|c| c.is_paused()).unwrap_or(false);
+            let reachability = client.as_ref().map(|c| reachability_str(c.reachability()));
             if runtime.is_alive() {
-                (SessionStatus::LoggedIn, true, socket_alive, paused, pair)
+                (
+                    SessionStatus::LoggedIn,
+                    true,
+                    socket_alive,
+                    paused,
+                    pair,
+                    reachability,
+                )
             } else {
                 let s = runtime.get_status();
                 let (status, is_logged_in) = if s == SessionStatus::LoggedIn {
@@ -289,7 +300,14 @@ pub async fn get_session_status(
                 } else {
                     (s, false)
                 };
-                (status, is_logged_in, socket_alive, paused, pair)
+                (
+                    status,
+                    is_logged_in,
+                    socket_alive,
+                    paused,
+                    pair,
+                    reachability,
+                )
             }
         } else {
             (
@@ -298,6 +316,7 @@ pub async fn get_session_status(
                 false,
                 false,
                 crate::models::sessions::PairStatus::default(),
+                None,
             )
         };
 
@@ -309,7 +328,26 @@ pub async fn get_session_status(
         phone_number: session.phone_number,
         push_name: session.push_name,
         pair,
+        reachability,
     }))
+}
+
+/// `whatsapp_rust::Reachability` carries no `Serialize`/`Display` of its own
+/// (see its upstream doc: reported by `Client::reachability`, waited out by
+/// `Client::wait_until_reachable`) -- own the string mapping here so a
+/// renamed/added upstream variant is a compile error, not a silently missing
+/// value on the wire.
+fn reachability_str(r: whatsapp_rust::Reachability) -> String {
+    use whatsapp_rust::Reachability;
+    match r {
+        Reachability::Reachable => "reachable",
+        Reachability::Reconnecting => "reconnecting",
+        Reachability::Paused => "paused",
+        Reachability::Unsupervised => "unsupervised",
+        Reachability::Finished => "finished",
+        _ => "unknown",
+    }
+    .to_string()
 }
 
 #[utoipa::path(
@@ -438,6 +476,245 @@ pub async fn connect_session(
     });
 
     Ok(Json(SuccessResponse::with_message("Connection initiated")))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct ConnectWaitQuery {
+    /// Session display name, only applied if the session doesn't exist yet.
+    pub name: Option<String>,
+    /// Device OS override, only applied if the session doesn't exist yet.
+    pub os: Option<String>,
+    /// Device platform override, only applied if the session doesn't exist yet.
+    pub platform: Option<String>,
+    /// Device version override, only applied if the session doesn't exist yet.
+    pub version: Option<String>,
+    /// Give up and close the stream after this many seconds with no
+    /// terminal event. Clamped to 5-600, default 180.
+    pub timeout_seconds: Option<u64>,
+}
+
+/// Creates the session if it doesn't exist, connects it if it isn't already
+/// connecting/connected, and streams the pairing flow end-to-end as
+/// server-sent events so a caller doesn't have to orchestrate
+/// `POST /sessions` + poll `/qr` + poll `/status` + watch webhooks by hand.
+///
+/// Emitted event names (each `data:` is the same JSON payload shape as the
+/// matching webhook, or a small inline object for the synthetic ones):
+/// - `qr_code` / `pair_code` -- forwarded verbatim as WhatsApp rotates them.
+/// - `connected` -- forwarded verbatim once paired.
+/// - `ready` -- synthetic terminal event. Fires immediately if the session
+///   was already logged in when the stream opened; otherwise fires after
+///   `connected` if history sync is disabled for this session
+///   (`skip_history_sync`), or after the upstream `offline_sync_completed`
+///   event otherwise.
+/// - `error` -- synthetic terminal event on `logged_out`.
+/// - `timeout` -- synthetic terminal event if no terminal state is reached
+///   before `timeout_seconds`.
+///
+/// The stream closes itself after any terminal event.
+#[utoipa::path(
+    get,
+    path = "/api/v1/sessions/{session_id}/connect/wait",
+    tag = "sessions",
+    security(("bearer_auth" = [])),
+    params(
+        ("session_id" = String, Path, description = "Session ID (created if it doesn't already exist)"),
+        ("name" = Option<String>, Query, description = "Session display name, only applied on first creation"),
+        ("os" = Option<String>, Query, description = "Device OS override, only applied on first creation"),
+        ("platform" = Option<String>, Query, description = "Device platform override, only applied on first creation"),
+        ("version" = Option<String>, Query, description = "Device version override, only applied on first creation"),
+        ("timeout_seconds" = Option<u64>, Query, description = "Give up after this many seconds with no terminal event (5-600, default 180)")
+    ),
+    responses(
+        (status = 200, description = "text/event-stream of the pairing flow: qr_code/pair_code -> connected -> ready, or error/timeout")
+    )
+)]
+pub async fn connect_and_wait(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Query(query): Query<ConnectWaitQuery>,
+) -> Result<Sse<impl Stream<Item = Result<SseEvent, std::convert::Infallible>>>, ApiError> {
+    let timeout = Duration::from_secs(query.timeout_seconds.unwrap_or(180).clamp(5, 600));
+    let runtime = ensure_connecting_for_wait(&state, &session_id, &query).await?;
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<SseEvent, std::convert::Infallible>>(32);
+
+    if runtime.is_alive() && runtime.get_status() == SessionStatus::LoggedIn {
+        tokio::spawn(async move {
+            let _ = tx
+                .send(Ok(SseEvent::default()
+                    .event("ready")
+                    .data(r#"{"already_connected":true}"#)))
+                .await;
+        });
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+        return Ok(Sse::new(stream).keep_alive(KeepAlive::default()));
+    }
+
+    let mut events_rx = runtime.subscribe_events();
+    let skip_sync = runtime.skip_history_sync();
+
+    tokio::spawn(async move {
+        let deadline = tokio::time::sleep(timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    let _ = tx
+                        .send(Ok(SseEvent::default().event("timeout").data("{}")))
+                        .await;
+                    return;
+                }
+                recv = events_rx.recv() => {
+                    let payload = match recv {
+                        Ok(p) => p,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    };
+                    let Ok(v) = serde_json::from_str::<serde_json::Value>(&payload) else {
+                        continue;
+                    };
+                    let event_name = v.get("event").and_then(|e| e.as_str()).unwrap_or("");
+                    match event_name {
+                        // Not collapsed into the match guard (as clippy's
+                        // `collapsible_match` suggests): the guard would move
+                        // `payload` even on a false result, making it
+                        // unavailable to the arms below.
+                        #[allow(clippy::collapsible_match)]
+                        "qr_code" | "pair_code" => {
+                            if tx
+                                .send(Ok(SseEvent::default().event(event_name).data(payload)))
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                        }
+                        "connected" => {
+                            if tx
+                                .send(Ok(SseEvent::default().event("connected").data(payload.clone())))
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                            if skip_sync {
+                                let _ = tx
+                                    .send(Ok(SseEvent::default().event("ready").data(payload)))
+                                    .await;
+                                return;
+                            }
+                        }
+                        "offline_sync_completed" => {
+                            let _ = tx
+                                .send(Ok(SseEvent::default().event("ready").data(payload)))
+                                .await;
+                            return;
+                        }
+                        "logged_out" => {
+                            let _ = tx
+                                .send(Ok(SseEvent::default().event("error").data(payload)))
+                                .await;
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keep-alive"),
+    ))
+}
+
+/// Idempotent connect trigger shared by [`connect_and_wait`]: creates the
+/// session row if it doesn't exist yet, then kicks off a connect unless one
+/// is already in flight or the session is already logged in (in which case
+/// the caller short-circuits without touching the client at all).
+async fn ensure_connecting_for_wait(
+    state: &AppState,
+    session_id: &str,
+    query: &ConnectWaitQuery,
+) -> Result<std::sync::Arc<crate::state::SessionState>, ApiError> {
+    let existing = state
+        .session_manager()
+        .get_session(session_id)
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    let storage_path = if existing.is_some() {
+        state
+            .session_manager()
+            .get_storage_path(session_id)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?
+            .unwrap_or_else(|| format!("{}/{}", state.base_storage_path(), session_id))
+    } else {
+        let storage_path = format!("{}/{}", state.base_storage_path(), session_id);
+        tokio::fs::create_dir_all(&storage_path)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        state
+            .session_manager()
+            .create_session(session_id, query.name.as_deref(), &storage_path)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        storage_path
+    };
+
+    let runtime = state.get_or_create_session(session_id, &storage_path);
+
+    if runtime.is_alive() && runtime.get_status() == SessionStatus::LoggedIn {
+        return Ok(runtime);
+    }
+
+    let s = runtime.get_status();
+    if matches!(
+        s,
+        SessionStatus::Connecting | SessionStatus::WaitingForQr | SessionStatus::WaitingForPairCode
+    ) {
+        return Ok(runtime);
+    }
+
+    if let Some(old_client) = runtime.get_client() {
+        old_client.disconnect().await;
+    }
+    runtime.set_client(None);
+    runtime.set_status(SessionStatus::Connecting);
+    runtime.clear_reconnecting();
+    runtime.clear_lock_cooldown();
+
+    let device_override =
+        if query.os.is_some() || query.platform.is_some() || query.version.is_some() {
+            Some(crate::device_props::resolve_with_override(
+                query.os.as_deref(),
+                query.platform.as_deref(),
+                query.version.as_deref(),
+            ))
+        } else {
+            None
+        };
+
+    let state_clone = state.clone();
+    let session_id_clone = session_id.to_string();
+    tokio::spawn(async move {
+        if let Err(e) = connect_client(&state_clone, &session_id_clone, device_override).await {
+            tracing::error!("Session {} connection failed: {}", session_id_clone, e);
+            let msg = e.to_string();
+            if let Some(runtime) = state_clone.get_session(&session_id_clone) {
+                runtime.set_status(SessionStatus::Disconnected);
+                runtime.set_client(None);
+                runtime.update_pair_state(|ps| ps.last_error = Some(msg));
+            }
+        }
+    });
+
+    Ok(runtime)
 }
 
 #[utoipa::path(
@@ -1572,7 +1849,6 @@ fn get_event_type(event: &wacore::types::events::Event) -> String {
         Event::IncomingCall(_) => "incoming_call".to_string(),
         Event::PictureUpdate(_) => "picture_update".to_string(),
         Event::UserAboutUpdate(_) => "user_about_update".to_string(),
-        Event::PushNameUpdate(_) => "push_name_update".to_string(),
         Event::SelfPushNameUpdated(_) => "push_name_update".to_string(),
         Event::ContactUpdate(_) => "contact_update".to_string(),
         Event::DeviceListUpdate(_) => "device_list_update".to_string(),
@@ -1951,7 +2227,7 @@ async fn persist_contact_event(
     let mut lid_str = None::<String>;
     let mut full_name = None::<String>;
     let mut first_name = None::<String>;
-    let mut push_name = None::<String>;
+    let push_name = None::<String>;
     let business_name = None::<String>;
     let source: &str;
 
@@ -1981,16 +2257,6 @@ async fn persist_contact_event(
             } else {
                 "appstate"
             };
-        }
-        Event::PushNameUpdate(u) => {
-            jid_str = u.jid.to_string();
-            if !u.new_push_name.is_empty() {
-                push_name = Some(u.new_push_name.clone());
-            }
-            if u.jid.server == wacore_binary::jid::SERVER_JID {
-                phone_str = Some(u.jid.user.to_string());
-            }
-            source = "push_name";
         }
         Event::ContactUpdated(u) => {
             jid_str = u.jid.to_string();
@@ -2083,13 +2349,6 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
                 "jid": update.jid.to_string(),
                 "status": update.status,
                 "timestamp": update.timestamp.timestamp(),
-            })
-        }
-        Event::PushNameUpdate(update) => {
-            serde_json::json!({
-                "jid": update.jid.to_string(),
-                "old_push_name": update.old_push_name,
-                "new_push_name": update.new_push_name,
             })
         }
         Event::SelfPushNameUpdated(update) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,7 @@ use state::AppState;
         handlers::contacts::get_profile_picture,
         handlers::contacts::get_user_info,
         handlers::contacts::list_contacts,
+        handlers::contacts::resolve_lid,
 
         handlers::groups::list_groups,
         handlers::groups::get_group,
@@ -365,6 +366,7 @@ use state::AppState;
             models::contacts::UserInfo,
             models::contacts::StoredContact,
             models::contacts::StoredContactListResponse,
+            models::contacts::LidPnEntryResponse,
 
             models::groups::GroupListResponse,
             models::groups::GroupInfo,

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ use state::AppState;
         handlers::sessions::get_session_status,
         handlers::sessions::get_qr_code,
         handlers::sessions::connect_session,
+        handlers::sessions::connect_and_wait,
         handlers::sessions::pair_session,
         handlers::sessions::disconnect_session,
         handlers::sessions::export_session,
@@ -203,6 +204,7 @@ use state::AppState;
         handlers::calls::play_call,
         handlers::calls::accept_call,
         handlers::calls::terminate_call,
+        handlers::calls::set_call_video_orientation,
         handlers::calls::transcribe_call,
 
         handlers::status::send_status_reaction,
@@ -403,6 +405,7 @@ use state::AppState;
             models::calls::AcceptCallRequest,
             models::calls::TerminateCallRequest,
             models::calls::TranscriptResponse,
+            models::calls::SetVideoOrientationRequest,
 
             models::status::StatusReactionRequest,
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,6 +22,16 @@
 //! - `waxum_session_socket_drops_total` — `Event::Disconnected` seen.
 //! - `waxum_session_reconnects_total` — `Event::Connected` that closed
 //!   an unplanned reconnect window (initial connects don't count).
+//!
+//! - `waxum_session_devices_unkeyed_total{session_id,reason}` — cumulative
+//!   count, read straight from the client's own `StatsSnapshot` each
+//!   scrape (so it's a gauge, not an incremented counter: whatsapp-rust
+//!   owns the running total, waxum only republishes it), of devices a
+//!   send gave up keying for. `reason` is one of `no_bundle`,
+//!   `session_setup`, `rejected`, `fetch_failed`, `encrypt` — see
+//!   whatsapp-rust's `agent_docs/observability.md` for what separates
+//!   them. A send drops the device and keeps going when this fires, so
+//!   this answers "how often", not "did the message fail".
 
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use prometheus::{Encoder, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder};
@@ -38,6 +48,7 @@ static WEBHOOK_CIRCUITS_OPEN: OnceLock<IntGauge> = OnceLock::new();
 static SESSION_SOCKET_ALIVE: OnceLock<IntGaugeVec> = OnceLock::new();
 static SESSION_DROPS: OnceLock<IntCounterVec> = OnceLock::new();
 static SESSION_RECONNECTS: OnceLock<IntCounterVec> = OnceLock::new();
+static SESSION_DEVICES_UNKEYED: OnceLock<IntGaugeVec> = OnceLock::new();
 
 /// Session ids we've already exported per-session series for, so the
 /// scrape loop can prune labels for sessions that were deleted —
@@ -101,6 +112,14 @@ fn registry() -> &'static Registry {
             &["session_id"],
         )
         .unwrap();
+        let session_devices_unkeyed = IntGaugeVec::new(
+            Opts::new(
+                "waxum_session_devices_unkeyed_total",
+                "Per-session, per-reason count of devices a send gave up keying for (from the client's own running total)",
+            ),
+            &["session_id", "reason"],
+        )
+        .unwrap();
         r.register(Box::new(sessions_total.clone())).unwrap();
         r.register(Box::new(sessions_live.clone())).unwrap();
         r.register(Box::new(process_threads.clone())).unwrap();
@@ -109,6 +128,8 @@ fn registry() -> &'static Registry {
         r.register(Box::new(session_socket_alive.clone())).unwrap();
         r.register(Box::new(session_drops.clone())).unwrap();
         r.register(Box::new(session_reconnects.clone())).unwrap();
+        r.register(Box::new(session_devices_unkeyed.clone()))
+            .unwrap();
         SESSIONS_TOTAL.set(sessions_total).ok();
         SESSIONS_LIVE.set(sessions_live).ok();
         PROCESS_THREADS.set(process_threads).ok();
@@ -117,6 +138,7 @@ fn registry() -> &'static Registry {
         SESSION_SOCKET_ALIVE.set(session_socket_alive).ok();
         SESSION_DROPS.set(session_drops).ok();
         SESSION_RECONNECTS.set(session_reconnects).ok();
+        SESSION_DEVICES_UNKEYED.set(session_devices_unkeyed).ok();
         r
     })
 }
@@ -160,6 +182,7 @@ pub async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse
     let mut total = 0i64;
     let mut live = 0i64;
     let socket_alive_vec = SESSION_SOCKET_ALIVE.get().unwrap();
+    let devices_unkeyed_vec = SESSION_DEVICES_UNKEYED.get().unwrap();
     let mut current_ids = std::collections::HashSet::new();
     for (session_id, s) in state.session_iter_with_ids() {
         total += 1;
@@ -169,6 +192,20 @@ pub async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse
         socket_alive_vec
             .with_label_values(&[session_id.as_str()])
             .set(if s.socket_alive() { 1 } else { 0 });
+        if let Some(client) = s.get_client() {
+            let stats = client.stats();
+            for (reason, value) in [
+                ("no_bundle", stats.devices_unkeyed_no_bundle),
+                ("session_setup", stats.devices_unkeyed_session_setup),
+                ("rejected", stats.devices_unkeyed_rejected),
+                ("fetch_failed", stats.devices_unkeyed_fetch_failed),
+                ("encrypt", stats.devices_unkeyed_encrypt),
+            ] {
+                devices_unkeyed_vec
+                    .with_label_values(&[session_id.as_str(), reason])
+                    .set(value as i64);
+            }
+        }
         current_ids.insert(session_id);
     }
     SESSIONS_TOTAL.get().unwrap().set(total);
@@ -182,6 +219,15 @@ pub async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse
         }
         if let Some(c) = SESSION_RECONNECTS.get() {
             let _ = c.remove_label_values(&[stale.as_str()]);
+        }
+        for reason in [
+            "no_bundle",
+            "session_setup",
+            "rejected",
+            "fetch_failed",
+            "encrypt",
+        ] {
+            let _ = devices_unkeyed_vec.remove_label_values(&[stale.as_str(), reason]);
         }
     }
     *seen = current_ids;

--- a/src/models/calls.rs
+++ b/src/models/calls.rs
@@ -175,3 +175,14 @@ pub struct VoiceEntry {
 pub struct TranscriptResponse {
     pub text: String,
 }
+
+/// Body for `POST /api/v1/sessions/{session_id}/calls/video-orientation`.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct SetVideoOrientationRequest {
+    pub call_id: String,
+    /// Camera rotation to announce to the peer, as quarter turns clockwise
+    /// (0-3). Applied to every `<video>` this call sends from now on; a
+    /// call that isn't sending video yet has the value applied once it
+    /// starts.
+    pub orientation: u8,
+}

--- a/src/models/contacts.rs
+++ b/src/models/contacts.rs
@@ -98,3 +98,18 @@ pub struct UserInfo {
 
     pub picture_id: Option<String>,
 }
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LidPnEntryResponse {
+    /// The LID user part (e.g. "100000012345678", no `@lid` suffix).
+    pub lid: String,
+
+    /// The phone number user part (e.g. "15551234567", no `@s.whatsapp.net` suffix).
+    pub phone_number: String,
+
+    /// Unix timestamp (seconds) when the mapping was first learned.
+    pub created_at: i64,
+
+    /// How the mapping was learned (usync, a peer's message, pairing, etc.).
+    pub learning_source: String,
+}

--- a/src/models/sessions.rs
+++ b/src/models/sessions.rs
@@ -227,6 +227,12 @@ pub struct SessionStatusResponse {
     pub push_name: Option<String>,
     /// Pair flow telemetry (always present, fields may be null)
     pub pair: PairStatus,
+    /// Finer-grained connection state from the underlying client's own
+    /// `reachability()`, distinct from `status`/`socket_alive`: one of
+    /// `reachable`, `reconnecting`, `paused`, `unsupervised` or `finished`.
+    /// `null` when there is no live client in this process at all (the
+    /// coarse `status`/`is_logged_in` above already cover that case).
+    pub reachability: Option<String>,
 }
 
 /// Device information

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -95,6 +95,10 @@ fn session_routes() -> Router<AppState> {
             "/{session_id}/connect",
             post(handlers::sessions::connect_session),
         )
+        .route(
+            "/{session_id}/connect/wait",
+            get(handlers::sessions::connect_and_wait),
+        )
         .route("/{session_id}/pair", post(handlers::sessions::pair_session))
         .route(
             "/{session_id}/disconnect",
@@ -389,6 +393,10 @@ fn session_routes() -> Router<AppState> {
         .route(
             "/{session_id}/calls/terminate",
             post(handlers::calls::terminate_call),
+        )
+        .route(
+            "/{session_id}/calls/video-orientation",
+            post(handlers::calls::set_call_video_orientation),
         )
         .route(
             "/{session_id}/status/react",

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -294,6 +294,10 @@ fn session_routes() -> Router<AppState> {
             get(handlers::contacts::get_profile_picture),
         )
         .route(
+            "/{session_id}/contacts/{jid}/lid",
+            get(handlers::contacts::resolve_lid),
+        )
+        .route(
             "/{session_id}/contacts/users",
             post(handlers::contacts::get_user_info),
         )

--- a/src/state.rs
+++ b/src/state.rs
@@ -483,7 +483,6 @@ impl SessionState {
         let _ = self.event_tx.send(event);
     }
 
-    #[allow(dead_code)]
     pub fn subscribe_events(&self) -> broadcast::Receiver<String> {
         self.event_tx.subscribe()
     }

--- a/tests/connect_wait.rs
+++ b/tests/connect_wait.rs
@@ -1,0 +1,46 @@
+mod common;
+
+use axum::body::to_bytes;
+use axum::http::StatusCode;
+use common::{req_get, Harness, TEST_TOKEN};
+use tower::ServiceExt;
+
+/// `GET /sessions/{id}/connect/wait` creates the session on first hit (no
+/// prior `POST /sessions` needed), streams SSE, and gives up cleanly with a
+/// `timeout` event once `timeout_seconds` elapses without a real WhatsApp
+/// connection to pair against -- exactly what happens in this test harness,
+/// which never touches the real network.
+#[tokio::test]
+async fn connect_wait_creates_session_and_times_out() {
+    let h = Harness::new().await;
+
+    let req = req_get(
+        "/api/v1/sessions/s-wait/connect/wait?timeout_seconds=5",
+        Some(TEST_TOKEN),
+    );
+    let res = h.app.clone().oneshot(req).await.expect("router response");
+    let status = res.status();
+    let content_type = res
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let body = to_bytes(res.into_body(), 1024 * 1024)
+        .await
+        .expect("body bytes");
+    let text = String::from_utf8_lossy(&body);
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(content_type.starts_with("text/event-stream"));
+    assert!(text.contains("event: timeout"), "body was: {text}");
+
+    // The session row now exists even though no client ever connected.
+    let (status, body) = common::call(
+        &h.app,
+        req_get("/api/v1/sessions/s-wait/status", Some(TEST_TOKEN)),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.pointer("/status").and_then(|v| v.as_str()).is_some());
+}

--- a/tests/connect_wait.rs
+++ b/tests/connect_wait.rs
@@ -9,7 +9,8 @@ use tower::ServiceExt;
 /// prior `POST /sessions` needed), streams SSE, and gives up cleanly with a
 /// `timeout` event once `timeout_seconds` elapses without a real WhatsApp
 /// connection to pair against -- exactly what happens in this test harness,
-/// which never touches the real network.
+/// which never touches the real network. The session row exists afterward
+/// even though no client ever connected.
 #[tokio::test]
 async fn connect_wait_creates_session_and_times_out() {
     let h = Harness::new().await;
@@ -35,7 +36,6 @@ async fn connect_wait_creates_session_and_times_out() {
     assert!(content_type.starts_with("text/event-stream"));
     assert!(text.contains("event: timeout"), "body was: {text}");
 
-    // The session row now exists even though no client ever connected.
     let (status, body) = common::call(
         &h.app,
         req_get("/api/v1/sessions/s-wait/status", Some(TEST_TOKEN)),

--- a/tests/lid_pn.rs
+++ b/tests/lid_pn.rs
@@ -1,0 +1,51 @@
+mod common;
+
+use axum::http::{Method, StatusCode};
+use common::{call, req_get, req_json, Harness, TEST_TOKEN};
+use serde_json::json;
+
+/// `GET /sessions/{id}/contacts/{jid}/lid` drives `Client::get_lid_pn_entry`,
+/// so it needs an installed client instance — a session that exists only as
+/// a DB row gets 503, not 404.
+#[tokio::test]
+async fn resolve_lid_requires_an_installed_client() {
+    let h = Harness::new().await;
+    let _ = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({"id": "s-lid"}),
+        ),
+    )
+    .await;
+
+    let (status, _) = call(
+        &h.app,
+        req_get(
+            "/api/v1/sessions/s-lid/contacts/100000012345678@lid/lid",
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// A totally unknown session returns 503 too (`get_client` checks the live
+/// registry, not the sessions table) — same class of response as any other
+/// endpoint gated on `handlers::messages::get_client`.
+#[tokio::test]
+async fn resolve_lid_unknown_session_returns_503() {
+    let h = Harness::new().await;
+
+    let (status, _) = call(
+        &h.app,
+        req_get(
+            "/api/v1/sessions/does-not-exist/contacts/100000012345678@lid/lid",
+            Some(TEST_TOKEN),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}


### PR DESCRIPTION
## Summary
- Bump vendored `whatsapp-rust`/`wacore`/etc. from `2b60761` to `1489b7d` (upstream `0.7.0`, 47 commits) — voip relay moved to sans-io `rtc-*` crates (transparent), `Event::PushNameUpdate` formally retired upstream (was already dead — nothing ever dispatched it), 3 now-dead match arms removed.
- **`POST /sessions/{id}/calls/video-orientation`** — new, via `CallHandle::set_video_orientation`.
- **`reachability`** field added to `GET /sessions/{id}/status` — via the new `Client::reachability()` (`reachable`/`reconnecting`/`paused`/`unsupervised`/`finished`).
- **`waxum_session_devices_unkeyed_total{session_id,reason}`** on `/metrics` — surfaces the new upstream send-observability counters (a message can "send" but silently fail to reach some devices; this makes that visible).
- **`GET /sessions/{id}/connect/wait`** — new one-shot SSE endpoint: create + connect + stream `qr_code`/`pair_code` → `connected` → `ready` (or `error`/`timeout`), so a caller doesn't have to hand-orchestrate `POST /sessions` + poll `/qr` + poll `/status` + webhooks. Built on the previously-unused per-session `event_tx` broadcast channel.

## Test plan
- [x] `cargo build -j 4`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -j 4 -- -D warnings`
- [x] `cargo test -j 4` (full suite, incl. new `connect_wait.rs`)
- [x] pre-push hook passed clean on `git push`