### PR TITLE
fix: raise default rate limit 20/50 -> 60/150 (#83)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,5 +59,12 @@ NATS_SEND_MAX_AGE_DAYS=1
 # disable ingestion (existing rows stay searchable).
 # MESSAGE_HISTORY_ENABLED=true
 
+# Per-peer-IP rate limit on the whole API (optional, defaults shown).
+# Keyed on the TCP peer address, so behind a reverse proxy every client
+# behind it shares one quota -- raise this if you're seeing
+# "Too Many Requests" from normal dashboard/UI usage.
+# RATE_LIMIT_PER_SECOND=60
+# RATE_LIMIT_BURST=150
+
 # Logging
 RUST_LOG=waxum=info,tower_http=info

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ impl utoipa::Modify for SecurityAddon {
 }
 
 /// Builds the global per-peer-IP rate limiter (`RATE_LIMIT_PER_SECOND` /
-/// `RATE_LIMIT_BURST` env vars, default 20/50) and spawns the background
+/// `RATE_LIMIT_BURST` env vars, default 60/150) and spawns the background
 /// task that periodically evicts stale entries from its state map --
 /// without that, the map only grows and becomes an unbounded memory leak
 /// in front of a public server.
@@ -543,11 +543,11 @@ fn build_rate_limiter(
     let per_second: u64 = std::env::var("RATE_LIMIT_PER_SECOND")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(20);
+        .unwrap_or(60);
     let burst: u32 = std::env::var("RATE_LIMIT_BURST")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(50);
+        .unwrap_or(150);
     let conf = Arc::new(
         GovernorConfigBuilder::default()
             .key_extractor(PeerIpKeyExtractor)


### PR DESCRIPTION
Fixes #83. `PeerIpKeyExtractor` keys on TCP peer, so behind a reverse proxy (Docker Compose / Traefik / Dokploy) every client shares one quota — 20 req/s burst 50 exhausts within a single dashboard page load plus a few clicks. Still overridable via `RATE_LIMIT_PER_SECOND`/`RATE_LIMIT_BURST`.