### PR TITLE
v0.12.4: make rate limiter opt-in (off by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,10 +59,11 @@ NATS_SEND_MAX_AGE_DAYS=1
 # disable ingestion (existing rows stay searchable).
 # MESSAGE_HISTORY_ENABLED=true
 
-# Per-peer-IP rate limit on the whole API (optional, defaults shown).
-# Keyed on the TCP peer address, so behind a reverse proxy every client
-# behind it shares one quota -- raise this if you're seeing
-# "Too Many Requests" from normal dashboard/UI usage.
+# Per-peer-IP rate limit on the whole API. Off by default -- keyed on
+# the TCP peer address, so behind a reverse proxy every client behind
+# it shares one quota (see #83). Set RATE_LIMIT_ENABLED=true to turn it
+# on, then tune the other two if the defaults don't fit.
+# RATE_LIMIT_ENABLED=true
 # RATE_LIMIT_PER_SECOND=60
 # RATE_LIMIT_BURST=150
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.12.4] - 2026-08-28
+
+### Changed
+
+Rate limiter is now opt-in (`RATE_LIMIT_ENABLED=true`, default off).
+`PeerIpKeyExtractor` keys on TCP peer, so behind a reverse proxy every
+client shares one quota — 0.12.3 raised the defaults, but a self-hosted
+single-operator deployment behind Docker Compose/Traefik/Dokploy still
+doesn't need it on by default. `RATE_LIMIT_PER_SECOND`/`RATE_LIMIT_BURST`
+still apply when it's turned on.
+
 ## [0.12.3] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to **waxum** will be documented in this file.
 
+## [0.12.3] - 2026-08-28
+
+### Fixed
+
+Default per-IP rate limit raised 20 req/s burst 50 -> 60 req/s burst
+150 (#83, #84). `PeerIpKeyExtractor` keys on TCP peer, so behind a
+reverse proxy (Docker Compose / Traefik / Dokploy) every client shares
+one quota — the old defaults exhausted within a single dashboard page
+load plus a few clicks. Still overridable via `RATE_LIMIT_PER_SECOND`/
+`RATE_LIMIT_BURST`, now documented in `.env.example`.
+
 ## [0.12.2] - 2026-08-23
 
 ### Changed — vendored whatsapp-rust bumped to `1489b7d` (upstream `0.7.0`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "waxum"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waxum"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -524,20 +524,20 @@ impl utoipa::Modify for SecurityAddon {
 /// `RATE_LIMIT_BURST` env vars, default 60/150) and spawns the background
 /// task that periodically evicts stale entries from its state map --
 /// without that, the map only grows and becomes an unbounded memory leak
-/// in front of a public server.
+/// in front of a public server. Only called when `RATE_LIMIT_ENABLED=true`
+/// (default off, see [`async_main`]): keyed on the TCP peer address
+/// ([`PeerIpKeyExtractor`]), so behind an unconfigured reverse proxy
+/// (Docker Compose, Traefik, Dokploy) every client shares one quota --
+/// #83/#84 hit exactly that, so this stays opt-in rather than a default
+/// every self-hosted deployment has to fight.
 ///
-/// No rate limiting existed anywhere in the stack before this -- a bearer
-/// token holder (or an unauthenticated caller hitting `/login`) could
-/// hammer pairing codes, blast sends, or webhook registration unbounded.
-/// Keyed on the TCP peer address ([`PeerIpKeyExtractor`]) rather than
-/// `X-Forwarded-For`/`X-Real-IP`: those headers are client-controlled
-/// unless a trusted proxy strips and re-sets them, and trusting them
-/// blindly would let a client bypass the limit entirely by sending a fresh
-/// fake IP on every request. The tradeoff is that behind an unconfigured
-/// reverse proxy every client shares one quota (the proxy's peer IP) --
-/// less precise, but not bypassable. Applied as the outermost layer in
-/// [`async_main`] so every request is rate-limited before it costs a JWT
-/// validation or reaches a handler.
+/// Keyed on the TCP peer address rather than `X-Forwarded-For`/
+/// `X-Real-IP`: those headers are client-controlled unless a trusted
+/// proxy strips and re-sets them, and trusting them blindly would let a
+/// client bypass the limit entirely by sending a fresh fake IP on every
+/// request. Applied as the outermost layer in [`async_main`] so every
+/// request is rate-limited before it costs a JWT validation or reaches a
+/// handler.
 fn build_rate_limiter(
 ) -> Arc<GovernorConfig<PeerIpKeyExtractor, governor::middleware::NoOpMiddleware>> {
     let per_second: u64 = std::env::var("RATE_LIMIT_PER_SECOND")
@@ -899,7 +899,10 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
     }
 
     let cors = build_cors_layer();
-    let governor_conf = build_rate_limiter();
+    let rate_limit_enabled = std::env::var("RATE_LIMIT_ENABLED")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(false);
 
     let (superadmin_token, from_env) = middleware::jwt::get_superadmin_token();
     println!();
@@ -922,7 +925,7 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
         .url("/api-docs/openapi.json", ApiDoc::openapi())
         .into();
 
-    let app = create_router()
+    let mut app = create_router()
         .merge(swagger_router)
         .merge(console::console_router())
         .layer(axum::middleware::from_fn_with_state(
@@ -930,9 +933,13 @@ async fn async_main(worker_threads: usize, blocking_threads: usize) -> Result<()
             middleware::jwt::jwt_auth_middleware,
         ))
         .layer(TraceLayer::new_for_http())
-        .layer(cors)
-        .layer(GovernorLayer::new(governor_conf))
-        .with_state(state);
+        .layer(cors);
+
+    if rate_limit_enabled {
+        app = app.layer(GovernorLayer::new(build_rate_limiter()));
+    }
+
+    let app = app.with_state(state);
 
     let port: u16 = std::env::var("PORT")
         .unwrap_or_else(|_| "3451".to_string())


### PR DESCRIPTION
## Summary
- v0.12.3 raised the rate-limit defaults (20/50 -> 60/150) but that alone wasn't enough for self-hosted single-operator deployments behind a reverse proxy.
- Rate limiting is now **opt-in**: `RATE_LIMIT_ENABLED=true` (default off). `RATE_LIMIT_PER_SECOND`/`RATE_LIMIT_BURST` still apply once enabled.
- `.env.example` updated to match.

Fixes #83.

## Test plan
- [x] `cargo build -j 4` / `cargo fmt --check` / `cargo clippy -j 4 -- -D warnings`
- [x] pre-push hook passed clean on `git push`