### PR TITLE
test: pin the HTTP contract for the mex handlers

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -96,6 +96,11 @@ pub fn req_json(method: Method, path: &str, token: Option<&str>, body: Value) ->
     b.body(Body::from(body.to_string())).expect("build request")
 }
 
+/// Carries `allow(dead_code)` for the same reason as `req_json` and
+/// `req_delete`: `common` is compiled once per integration-test binary, so a
+/// module that only exercises one HTTP method leaves the other constructors
+/// unused and would otherwise fail `clippy -D warnings`.
+#[allow(dead_code)]
 pub fn req_get(path: &str, token: Option<&str>) -> Request<Body> {
     let mut b = Request::builder().method(Method::GET).uri(path);
     if let Some(t) = token {

--- a/tests/mex.rs
+++ b/tests/mex.rs
@@ -1,0 +1,219 @@
+//! Contract tests for the mex handlers (`src/handlers/mex.rs`), the
+//! passthrough to WhatsApp's internal GraphQL ("mex") endpoint.
+//!
+//! # These routes are not reachable
+//!
+//! `mex_query` and `mex_mutate` are written, compiled, and registered with
+//! utoipa in `src/main.rs`, so `/api/v1/sessions/{session_id}/mex/query` and
+//! `.../mex/mutate` both appear in the published OpenAPI document. Neither is
+//! wired into `create_router` in `src/routes/mod.rs`. Every request to them
+//! therefore falls through to the router's 404, and the handler bodies are
+//! dead code at runtime.
+//!
+//! That makes the honest contract for this module "the documented path does
+//! not exist", and that is what the first two tests assert. They are written
+//! as characterization tests: they pin the current, wrong behaviour so that
+//! it is visible in CI instead of only in the OpenAPI diff, and they fail the
+//! moment someone registers the routes. The change that registers them is
+//! expected to delete those two tests and un-`ignore` the four below it,
+//! which spell out the contract the handlers already implement.
+//!
+//! Per the workstream rule, the fix is not in this PR.
+//!
+//! # The intended contract
+//!
+//! Both handlers resolve their client through the same local `get_client` as
+//! every other session-scoped module, so once routed they follow the pattern
+//! documented in `tests/presence.rs` exactly: 401 without a token, 503 for an
+//! unknown session, 503 for a session that exists in the database but has
+//! never connected, and a body rejection at extraction time for a body that
+//! does not deserialize.
+//!
+//! Nothing past the client gate is assertable — `mex()` is a thin passthrough
+//! whose only logic is `build_mex_doc`'s fallback name and the flattening of
+//! upstream GraphQL errors, both of which need a live client to reach.
+
+mod common;
+
+use axum::http::{Method, StatusCode};
+use common::{call, req_json, Harness, TEST_TOKEN};
+use serde_json::json;
+
+const SESSION: &str = "s-mex";
+
+const QUERY_PATH: &str = "/api/v1/sessions/s-mex/mex/query";
+const MUTATE_PATH: &str = "/api/v1/sessions/s-mex/mex/mutate";
+
+/// Creates a session row (no live client is ever attached in tests).
+async fn seed_session(h: &Harness, id: &str) {
+    let (status, body) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            "/api/v1/sessions",
+            Some(TEST_TOKEN),
+            json!({ "id": id }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "seeding session {id} should succeed: {body:?}"
+    );
+}
+
+fn query_body() -> serde_json::Value {
+    json!({ "doc_id": "1234567890", "variables": {} })
+}
+
+/// Characterization test. Both mex paths are absent from the router, so an
+/// authenticated request with a well-formed body gets 404 rather than the 503
+/// that `get_client` would produce. The presence route on the same session is
+/// the control: it is registered, takes the same shape, and returns 503, so a
+/// 404 here is a routing gap and not something about the session or the body.
+#[tokio::test]
+async fn mex_routes_are_documented_but_not_registered() {
+    let h = Harness::new().await;
+    seed_session(&h, SESSION).await;
+
+    for path in [QUERY_PATH, MUTATE_PATH] {
+        let (status, _) = call(
+            &h.app,
+            req_json(Method::POST, path, Some(TEST_TOKEN), query_body()),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "{path} is in the OpenAPI document but not in create_router"
+        );
+    }
+
+    let (control_status, _) = call(
+        &h.app,
+        req_json(
+            Method::POST,
+            &format!("/api/v1/sessions/{SESSION}/presence/set"),
+            Some(TEST_TOKEN),
+            json!({ "status": "available" }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        control_status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a registered session-scoped route reaches the client gate"
+    );
+}
+
+/// The JWT middleware is layered around the whole router, so it runs before
+/// routing and an unauthenticated request to a path that does not exist is
+/// still 401. Worth pinning precisely because it is misleading: a 401 here
+/// says nothing about whether the route is registered, which is why the test
+/// above supplies a token.
+#[tokio::test]
+async fn mex_routes_return_401_before_routing_is_consulted() {
+    let h = Harness::new().await;
+
+    for path in [QUERY_PATH, MUTATE_PATH] {
+        let (status, _) = call(&h.app, req_json(Method::POST, path, None, query_body())).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "{path}: auth is checked ahead of routing"
+        );
+    }
+}
+
+/// Un-ignore together with the three below once the routes are registered.
+#[tokio::test]
+#[ignore = "mex routes are not registered in create_router; see the module doc"]
+async fn mex_routes_require_a_token() {
+    let h = Harness::new().await;
+
+    for path in [QUERY_PATH, MUTATE_PATH] {
+        let (status, _) = call(&h.app, req_json(Method::POST, path, None, query_body())).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "unauthenticated {path}");
+    }
+}
+
+#[tokio::test]
+#[ignore = "mex routes are not registered in create_router; see the module doc"]
+async fn mex_routes_reject_an_unknown_session() {
+    let h = Harness::new().await;
+
+    for path in [
+        "/api/v1/sessions/does-not-exist/mex/query",
+        "/api/v1/sessions/does-not-exist/mex/mutate",
+    ] {
+        let (status, _) = call(
+            &h.app,
+            req_json(Method::POST, path, Some(TEST_TOKEN), query_body()),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{path} should fail at the client gate"
+        );
+    }
+}
+
+/// `get_client` reads the live registry, not the `sessions` table, so a
+/// session row on its own does not change the outcome — 503, never 404.
+#[tokio::test]
+#[ignore = "mex routes are not registered in create_router; see the module doc"]
+async fn mex_routes_reject_a_session_that_never_connected() {
+    let h = Harness::new().await;
+    seed_session(&h, SESSION).await;
+
+    for path in [QUERY_PATH, MUTATE_PATH] {
+        let (status, _) = call(
+            &h.app,
+            req_json(Method::POST, path, Some(TEST_TOKEN), query_body()),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{path} has a DB row but no live client"
+        );
+    }
+}
+
+/// `doc_id` and `variables` are both required — only `doc_name` has a serde
+/// default. `Json<T>` is the last extractor, so a body missing either one is
+/// rejected before the handler body and never reaches the client gate.
+#[tokio::test]
+#[ignore = "mex routes are not registered in create_router; see the module doc"]
+async fn mex_routes_reject_a_body_missing_required_fields() {
+    let h = Harness::new().await;
+    seed_session(&h, SESSION).await;
+
+    let bad_bodies = [
+        json!({}),
+        json!({ "variables": {} }),
+        json!({ "doc_id": "1234567890" }),
+        json!({ "doc_id": 1234567890, "variables": {} }),
+    ];
+
+    for path in [QUERY_PATH, MUTATE_PATH] {
+        for body in &bad_bodies {
+            let (status, _) = call(
+                &h.app,
+                req_json(Method::POST, path, Some(TEST_TOKEN), body.clone()),
+            )
+            .await;
+            assert_ne!(
+                status,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "{path} with {body}: extraction must fail before the client gate"
+            );
+            assert!(
+                status.is_client_error(),
+                "{path} with {body}: expected a client error, got {status}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Part of IMT-19 (v0.13.0 W3, test breadth). Covers both handlers in `src/handlers/mex.rs` with a new `tests/mex.rs`.

## Covering this module turned up a defect: neither route is reachable

`mex_query` and `mex_mutate` are written, compiled, and registered with utoipa in `src/main.rs:217-218`, so `/api/v1/sessions/{session_id}/mex/query` and `.../mex/mutate` both appear in the published OpenAPI document. Neither is wired into `create_router` in `src/routes/mod.rs`. Every request to them falls through to the router 404, and both handler bodies are dead code at runtime.

Per the workstream rule the fix is not in this PR; it is filed separately.

## What is asserted

Two characterization tests pin the current, wrong behaviour so it is visible in CI rather than only in an OpenAPI diff:

- `mex_routes_are_documented_but_not_registered` asserts the 404 with a control in the same test. The presence route on the same session, same request shape, returns 503 at its client gate. So the 404 is a routing gap, not something about the session or the body.
- `mex_routes_return_401_before_routing_is_consulted` pins that the JWT middleware is layered around the whole router and therefore runs ahead of routing. An unauthenticated request to a path that does not exist is still 401. Worth pinning precisely because it is misleading: a 401 here says nothing about whether the route is registered, which is why the first test supplies a token.

Four further tests spell out the contract the handlers already implement once routed, matching `tests/presence.rs` exactly: 401 without a token, 503 for an unknown session, 503 for a DB-only session, and a body rejection at extraction for a body missing `doc_id` or `variables`. They are `#[ignore]`d against the routing gap.

**The PR that registers the routes should delete the two characterization tests and un-`ignore` these four.** That gives the fix its acceptance criteria for free.

## On what is worth pinning

`mex` is a passthrough, so most of what could be asserted only restates the type signature. The only logic in the module is `build_mex_doc`'s fallback name and the flattening of upstream GraphQL errors into `MexGraphQLErrorItem`, both of which sit past the client gate and need a live client. Nothing there is assertable in an integration test, so the file does not pretend otherwise.

## Shared surface

Marks `req_get` in `tests/common/mod.rs` `#[allow(dead_code)]`, matching `req_json` and `req_delete`. `common` is compiled once per integration-test binary, so a module that exercises a single HTTP method leaves the other constructors unused and fails `clippy -D warnings`. `tests/mex.rs` is POST-only and hit this. One line, but flagging it since `tests/common/mod.rs` is shared and this will bite the next POST-only or GET-only module too.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test` all pass: 101 tests, 0 failures, 4 ignored.

Companion PR for `calls` is #91, one PR per module as agreed.