### PR TITLE
docs(labels): match the remove_message_label annotation to the router

### DIFF
--- a/src/handlers/labels.rs
+++ b/src/handlers/labels.rs
@@ -151,9 +151,9 @@ pub async fn add_message_label(
 }
 
 #[utoipa::path(
-    delete,
+    post,
     security(("bearer_auth" = [])),
-    path = "/api/v1/sessions/{session_id}/labels/{label_id}/messages",
+    path = "/api/v1/sessions/{session_id}/labels/{label_id}/messages/remove",
     tag = "labels",
     params(("session_id" = String, Path, description = "Session ID"), ("label_id" = String, Path, description = "Label ID")),
     request_body = MessageLabelRequest,


### PR DESCRIPTION
Part 1 of IMT-27, taking the board decision recorded on IMT-22: correct the document, do not move the public path.

## The drift

`remove_message_label` was published as:

```
DELETE /api/v1/sessions/{session_id}/labels/{label_id}/messages
```

but the router serves it as:

```
POST /api/v1/sessions/{session_id}/labels/{label_id}/messages/remove
```

The documented path is registered for `POST` only, via `add_message_label`. A client generated from the published OpenAPI document therefore got `405 Method Not Allowed`, and the endpoint that actually works did not appear in the document at all.

## The change

One `#[utoipa::path(...)]` annotation: `delete` becomes `post`, and the path gains the `/remove` suffix. That is the whole diff.

No route, handler, request body or response changes. Nothing an existing caller does changes behaviour; the document now describes what the server has been serving all along.

The alternative considered and rejected was moving the router to `DELETE .../messages`, which is the tidier REST shape and symmetric with the `add_chat_label` / `remove_chat_label` pair one route above. It was rejected because it moves a public path. That asymmetry stays, deliberately.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all clean on the pinned nightly. The repo has no CI wired to PRs, so those runs are local.

Grepped the rest of the tree for the old path in Markdown, JSON, YAML and TypeScript: no other references. The OpenAPI document is generated from these annotations alone.

## Not in this PR

Part 2 of IMT-27 is untouched: `CreateLabelRequest.color` is accepted, documented as a hex value, and silently discarded by `create_label`, which reads only `color_id`. That needs its own decision and stays open on IMT-27.

Refs IMT-27.
