### PR TITLE
fix(routes): register the mex query and mutate routes

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -367,6 +367,8 @@ fn session_routes() -> Router<AppState> {
             "/{session_id}/chatstate/typing",
             post(handlers::chatstate::send_typing),
         )
+        .route("/{session_id}/mex/query", post(handlers::mex::mex_query))
+        .route("/{session_id}/mex/mutate", post(handlers::mex::mex_mutate))
         .route(
             "/{session_id}/calls/reject",
             post(handlers::calls::reject_call),

--- a/tests/mex.rs
+++ b/tests/mex.rs
@@ -1,26 +1,16 @@
 //! Contract tests for the mex handlers (`src/handlers/mex.rs`), the
 //! passthrough to WhatsApp's internal GraphQL ("mex") endpoint.
 //!
-//! # These routes are not reachable
+//! # The contract
 //!
-//! `mex_query` and `mex_mutate` are written, compiled, and registered with
-//! utoipa in `src/main.rs`, so `/api/v1/sessions/{session_id}/mex/query` and
-//! `.../mex/mutate` both appear in the published OpenAPI document. Neither is
-//! wired into `create_router` in `src/routes/mod.rs`. Every request to them
-//! therefore falls through to the router's 404, and the handler bodies are
-//! dead code at runtime.
-//!
-//! That makes the honest contract for this module "the documented path does
-//! not exist", and that is what the first two tests assert. They are written
-//! as characterization tests: they pin the current, wrong behaviour so that
-//! it is visible in CI instead of only in the OpenAPI diff, and they fail the
-//! moment someone registers the routes. The change that registers them is
-//! expected to delete those two tests and un-`ignore` the four below it,
-//! which spell out the contract the handlers already implement.
-//!
-//! Per the workstream rule, the fix is not in this PR.
-//!
-//! # The intended contract
+//! `mex_query` and `mex_mutate` back `/api/v1/sessions/{session_id}/mex/query`
+//! and `.../mex/mutate`. Both were registered with utoipa in `src/main.rs`
+//! long before they were wired into `create_router`, so for several releases
+//! they were published in the OpenAPI document while every request to them
+//! fell through to the router's 404. The two characterization tests that
+//! pinned that gap lived here and were deleted when the routes were
+//! registered in `src/routes/mod.rs` (IMT-28); the four tests below are the
+//! contract the handlers had implemented all along.
 //!
 //! Both handlers resolve their client through the same local `get_client` as
 //! every other session-scoped module, so once routed they follow the pattern
@@ -67,68 +57,11 @@ fn query_body() -> serde_json::Value {
     json!({ "doc_id": "1234567890", "variables": {} })
 }
 
-/// Characterization test. Both mex paths are absent from the router, so an
-/// authenticated request with a well-formed body gets 404 rather than the 503
-/// that `get_client` would produce. The presence route on the same session is
-/// the control: it is registered, takes the same shape, and returns 503, so a
-/// 404 here is a routing gap and not something about the session or the body.
+/// The JWT middleware is layered around the whole router, so a missing token
+/// is rejected ahead of routing. This says nothing about whether the route is
+/// registered — which is why every test below that cares about routing sends
+/// a token.
 #[tokio::test]
-async fn mex_routes_are_documented_but_not_registered() {
-    let h = Harness::new().await;
-    seed_session(&h, SESSION).await;
-
-    for path in [QUERY_PATH, MUTATE_PATH] {
-        let (status, _) = call(
-            &h.app,
-            req_json(Method::POST, path, Some(TEST_TOKEN), query_body()),
-        )
-        .await;
-        assert_eq!(
-            status,
-            StatusCode::NOT_FOUND,
-            "{path} is in the OpenAPI document but not in create_router"
-        );
-    }
-
-    let (control_status, _) = call(
-        &h.app,
-        req_json(
-            Method::POST,
-            &format!("/api/v1/sessions/{SESSION}/presence/set"),
-            Some(TEST_TOKEN),
-            json!({ "status": "available" }),
-        ),
-    )
-    .await;
-    assert_eq!(
-        control_status,
-        StatusCode::SERVICE_UNAVAILABLE,
-        "a registered session-scoped route reaches the client gate"
-    );
-}
-
-/// The JWT middleware is layered around the whole router, so it runs before
-/// routing and an unauthenticated request to a path that does not exist is
-/// still 401. Worth pinning precisely because it is misleading: a 401 here
-/// says nothing about whether the route is registered, which is why the test
-/// above supplies a token.
-#[tokio::test]
-async fn mex_routes_return_401_before_routing_is_consulted() {
-    let h = Harness::new().await;
-
-    for path in [QUERY_PATH, MUTATE_PATH] {
-        let (status, _) = call(&h.app, req_json(Method::POST, path, None, query_body())).await;
-        assert_eq!(
-            status,
-            StatusCode::UNAUTHORIZED,
-            "{path}: auth is checked ahead of routing"
-        );
-    }
-}
-
-/// Un-ignore together with the three below once the routes are registered.
-#[tokio::test]
-#[ignore = "mex routes are not registered in create_router; see the module doc"]
 async fn mex_routes_require_a_token() {
     let h = Harness::new().await;
 
@@ -139,7 +72,6 @@ async fn mex_routes_require_a_token() {
 }
 
 #[tokio::test]
-#[ignore = "mex routes are not registered in create_router; see the module doc"]
 async fn mex_routes_reject_an_unknown_session() {
     let h = Harness::new().await;
 
@@ -163,7 +95,6 @@ async fn mex_routes_reject_an_unknown_session() {
 /// `get_client` reads the live registry, not the `sessions` table, so a
 /// session row on its own does not change the outcome — 503, never 404.
 #[tokio::test]
-#[ignore = "mex routes are not registered in create_router; see the module doc"]
 async fn mex_routes_reject_a_session_that_never_connected() {
     let h = Harness::new().await;
     seed_session(&h, SESSION).await;
@@ -186,7 +117,6 @@ async fn mex_routes_reject_a_session_that_never_connected() {
 /// default. `Json<T>` is the last extractor, so a body missing either one is
 /// rejected before the handler body and never reaches the client gate.
 #[tokio::test]
-#[ignore = "mex routes are not registered in create_router; see the module doc"]
 async fn mex_routes_reject_a_body_missing_required_fields() {
     let h = Harness::new().await;
     seed_session(&h, SESSION).await;


### PR DESCRIPTION
Closes IMT-28. Lands on top of #92, which added `tests/mex.rs`.

## The defect

`mex_query` and `mex_mutate` were registered with utoipa in `src/main.rs:217-218`, so both paths were published in the OpenAPI document and rendered in Swagger UI:

- `POST /api/v1/sessions/{session_id}/mex/query`
- `POST /api/v1/sessions/{session_id}/mex/mutate`

Neither was wired into `create_router`. Every request fell through to the router's 404 and both handler bodies were dead code at runtime.

The failure was silent from every angle: `cargo build` was clean because the handlers are `pub` and referenced by the utoipa macro, nothing logged at startup, and an unauthenticated probe returns 401 rather than 404 because the JWT middleware is layered around the whole router and runs ahead of routing. Anyone generating a client from the spec got two endpoints that always 404.

## The fix

Two lines in `session_routes()`, placed with the other session-scoped modules:

```rust
.route("/{session_id}/mex/query", post(handlers::mex::mex_query))
.route("/{session_id}/mex/mutate", post(handlers::mex::mex_mutate))
```

The handlers needed no changes.

## Tests

`tests/mex.rs` from #92 pinned the gap with two characterization tests and carried the real contract behind `#[ignore]`. This PR does what that file's module doc said the fix should do:

- Deletes `mex_routes_are_documented_but_not_registered` and `mex_routes_return_401_before_routing_is_consulted`.
- Drops the four `#[ignore]` attributes.
- Rewrites the module doc header, which described the routes as unreachable and would have been actively misleading left in place.

**The four contract assertions are unmodified** — the only non-comment changes to `tests/mex.rs` are the two deletions and the four removed attributes. They pass as written: 401 without a token, 503 for an unknown session, 503 for a session with a database row that never connected, and a body rejection at extraction for a body missing `doc_id` or `variables`.

```
running 4 tests
test mex_routes_require_a_token ... ok
test mex_routes_reject_an_unknown_session ... ok
test mex_routes_reject_a_session_that_never_connected ... ok
test mex_routes_reject_a_body_missing_required_fields ... ok

test result: ok. 4 passed; 0 failed; 0 ignored
```

Full suite: **128 passed, 0 failed, 0 ignored** across all 19 test binaries. `cargo clippy --all-targets -- -D warnings` clean.

## Follow-up

Nothing asserts that every utoipa-registered path is actually routed. IMT-22 (labels OpenAPI/router drift) is a second instance of this same class, so a generic guard against the generated OpenAPI document would retire the category rather than picking it off one module at a time. Filed separately; out of scope here.