### PR TITLE
docs: MIT LICENSE file, nightly toolchain pin, and upstream dependency policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,45 @@ git clone https://github.com/imtaqin/waxum.git
 cd waxum
 ```
 
-The crate targets Rust **nightly** because the upstream `whatsapp-rust`
-client relies on the `portable_simd` feature. Install with:
+## Toolchain
 
-```sh
-rustup default nightly
-```
+The crate builds on a **pinned Rust nightly — `nightly-2026-04-05`**.
+
+You do not need to install or select it by hand. The pin lives in
+`rust-toolchain.toml`; `rustup` reads that file and installs the matching
+toolchain on your first `cargo` invocation in this directory. Do not run
+`rustup default nightly` — that sets a floating latest-nightly globally,
+which is not what this project builds against and will drift.
+
+The pin exists because upstream `whatsapp-rust` used `portable_simd`, an
+unstable feature. That is no longer true at the revision we pin — upstream
+removed SIMD and declares a stable MSRV, and waxum uses no unstable
+features of its own — so the pin is likely removable, but has not been
+verified against stable. Do not quietly change it; see
+[docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) and
+[#87](https://github.com/imtaqin/waxum/issues/87).
+
+## Upstream dependency policy
+
+waxum pins **eight** `whatsapp-rust` crates — `whatsapp-rust`, `wacore`,
+`wacore-binary`, `waproto`, `whatsapp-rust-sqlite-storage`,
+`whatsapp-rust-tokio-transport`, `whatsapp-rust-ureq-http-client`, and
+`whatsapp-rust-chat-store` — to a **single git revision**, not to
+crates.io versions.
+
+Rules, if you touch these:
+
+- **All eight move together, to the same revision.** They share types
+  across their public APIs; a mixed set does not compile.
+- **Do not switch any of them to a crates.io version.** Seven are
+  published, one (`whatsapp-rust-chat-store`) is not, and the set has to
+  resolve from one source.
+- **The revision is reviewed once per release**, as a checklist item in
+  the release process below — not continuously, and not on a cron.
+
+The full reasoning, the risks this carries, and what it means for anyone
+depending on waxum are in **[docs/DEPENDENCIES.md](docs/DEPENDENCIES.md)**.
+Read it before proposing a dependency change.
 
 ## Building & running
 
@@ -98,13 +131,21 @@ are really just an OOM. Cap it if you hit that: `cargo build -j 4` /
 
 The release flow is manual:
 
-1. Bump the `version` field in `Cargo.toml`.
-2. Add a `## [x.y.z]` section to `CHANGELOG.md` with what changed.
-3. `git commit -am "release x.y.z <short summary>"`.
-4. `git push origin main` — the `release.yml` workflow tags the commit,
+1. **Review the upstream `whatsapp-rust` revision.** Compare the pin in
+   `Cargo.toml` against upstream `main` and read the intervening changes
+   for protocol or API breaks. Bumping is optional; *looking* is not.
+   If you bump, move all eight crates to the same revision and smoke-test
+   a real pair + send — protocol regressions do not show up in
+   `cargo test`. Record the outcome either way in `CHANGELOG.md`, so the
+   next release knows the decision was made rather than skipped. See
+   [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md#bump-cadence).
+2. Bump the `version` field in `Cargo.toml`.
+3. Add a `## [x.y.z]` section to `CHANGELOG.md` with what changed.
+4. `git commit -am "release x.y.z <short summary>"`.
+5. `git push origin main` — the `release.yml` workflow tags the commit,
    builds multi-arch binaries + Docker image, and publishes the
    GitHub release.
-5. On the production server: `docker pull fdciabdul/waxum:latest`, then
+6. On the production server: `docker pull fdciabdul/waxum:latest`, then
    `docker cp` the binary out of a temporary container and
    `pm2 restart waxum` (see the internal deploy runbook).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 taqin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,32 @@ cargo build --release
 ./target/release/waxum
 ```
 
+### Toolchain
+
+**waxum builds on a pinned Rust nightly — `nightly-2026-04-05`.** You do
+not have to select it: the pin lives in `rust-toolchain.toml`, and
+`rustup` reads that file and installs the right toolchain on your first
+`cargo build`. If you have `rustup`, there is nothing to do.
+
+The pin is historical. Upstream `whatsapp-rust` used the unstable
+`portable_simd` feature, which is nightly-only; at the revision waxum
+currently pins, upstream has removed SIMD from its tree and declares a
+stable MSRV, and waxum itself uses no unstable features. The pin has not
+been re-validated against stable, so it stays until someone does that
+end to end. Tracked in
+[#87](https://github.com/imtaqin/waxum/issues/87).
+
+### Dependencies
+
+The WhatsApp protocol layer is not ours. It is
+[`whatsapp-rust`](https://github.com/oxidezap/whatsapp-rust), a
+third-party project, and waxum pins eight of its crates to a single git
+revision rather than to crates.io versions. That is a deliberate choice
+with real consequences for anyone depending on waxum — including that
+waxum cannot itself be published to crates.io. The reasoning, the risk,
+and the bump cadence are written down in
+**[docs/DEPENDENCIES.md](docs/DEPENDENCIES.md)**.
+
 ## Endpoints
 
 | URL | Purpose |

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,113 @@
+# Dependency policy
+
+waxum is a gateway, not a protocol implementation. The WhatsApp Web
+protocol layer — handshake, Noise transport, Signal-protocol session
+handling, binary node encoding, app-state sync — comes from
+[`whatsapp-rust`](https://github.com/oxidezap/whatsapp-rust), a
+third-party open-source project we do not control.
+
+This document states what we depend on, how we pin it, when we move the
+pin, and what that means for you if you depend on waxum.
+
+## What we pin
+
+Eight crates, all from the same upstream repository, all pinned to one
+git revision:
+
+| Crate | On crates.io |
+|---|---|
+| `whatsapp-rust` | 0.7.0 |
+| `wacore` | 0.7.0 |
+| `wacore-binary` | 0.7.0 |
+| `waproto` | 0.7.0 |
+| `whatsapp-rust-sqlite-storage` | 0.7.0 |
+| `whatsapp-rust-tokio-transport` | 0.7.0 |
+| `whatsapp-rust-ureq-http-client` | 0.7.0 |
+| `whatsapp-rust-chat-store` | **not published** |
+
+The current revision is recorded in `Cargo.toml`; the exact resolved
+commit is in `Cargo.lock`.
+
+## Why a git pin and not crates.io
+
+Seven of the eight crates are published. `whatsapp-rust-chat-store` is
+not, and waxum uses it for chat/message persistence.
+
+The eight crates are not independent: they share types across their
+public APIs. A `wacore` pulled from crates.io and a `wacore` pulled from
+git are, to the compiler, two different crates with two different sets of
+types — passing a value from one into the other does not compile. So the
+whole set has to resolve from the same source. One unpublished crate
+therefore forces all eight onto git.
+
+A secondary reason: the pinned revision is usually ahead of the last
+crates.io release, so the git pin is also where bug fixes land first.
+
+## What this costs, and what it means for you
+
+Be aware of this before you build on waxum:
+
+- **waxum cannot be published to crates.io.** Cargo refuses to publish a
+  crate with git dependencies. If you want waxum as a library dependency,
+  you must depend on it by git too, and inherit the same constraint. As a
+  deployed binary — the normal way to run waxum — this does not affect
+  you at all.
+- **No semver on the protocol layer.** A git revision carries no
+  compatibility promise. Moving the pin can break the build or change
+  behaviour with no version number signalling it. This is why the pin
+  moves on a schedule (below) rather than opportunistically.
+- **Weaker advisory coverage.** `cargo audit` matches RustSec advisories
+  and yanks against crates.io versions. Git-pinned crates are matched far
+  less reliably, so an advisory affecting the protocol layer may not
+  surface in our CI audit. This is the one that most deserves attention.
+- **Bus factor.** `whatsapp-rust` is a third-party project. If it stops
+  being maintained, waxum's protocol layer stops receiving fixes, and
+  taking that over means maintaining a WhatsApp protocol implementation
+  in Rust — a materially different project from maintaining a REST
+  gateway. We accept this risk knowingly rather than mitigate it: a fork
+  costs more than it buys today.
+
+We are not going to fork or vendor `whatsapp-rust` to escape any of the
+above. The upstream project is healthy and moves faster than we would.
+Making the exposure legible is the mitigation.
+
+## Toolchain
+
+`rust-toolchain.toml` pins `nightly-2026-04-05`. `rustup` honours that
+file automatically, so contributors get the right toolchain without
+choosing it.
+
+The reason for nightly was upstream's use of `portable_simd`, an unstable
+feature. That reason no longer holds at the revision we pin: upstream has
+removed SIMD from its tree, declares a stable MSRV, and gates no unstable
+features. waxum's own sources declare no `#![feature]` gates either.
+
+On the available evidence the pin is probably removable — but "probably"
+is not "verified", and nobody has run a stable build end to end. Until
+someone does, the pin stays and this is the honest description of it.
+Tracked in [#87](https://github.com/imtaqin/waxum/issues/87).
+
+## Bump cadence
+
+**The upstream revision is reviewed once per release.** Not on a cron, not
+continuously — it is a checklist item in the release process
+(see [CONTRIBUTING.md](../CONTRIBUTING.md#releasing)), which makes it a
+decision someone makes deliberately rather than a background upgrade that
+lands unreviewed.
+
+Reviewing does not mean always bumping. Staying put is a valid outcome;
+what is not valid is not looking. At each release:
+
+1. Compare the pinned revision against upstream `main`.
+2. Read the intervening changes for protocol or API breaks.
+3. If bumping: update all eight revisions together — they must stay on
+   one revision — then run the full quality gates and a real pairing +
+   send smoke test against a live session. Protocol regressions do not
+   show up in `cargo test`.
+4. Record the bump, and the reason, in `CHANGELOG.md`.
+5. If not bumping, say so in the release notes so the next person knows
+   the decision was made rather than missed.
+
+Check whether the unpublished crate has been published at the same time.
+If all eight land on crates.io, most of this document stops applying and
+we should move to version requirements.


### PR DESCRIPTION
Trust-hygiene work for v0.13.0. Two commits, no behaviour change — docs and licensing only.

## `7829286` — MIT LICENSE at the repo root (IMT-17)

`Cargo.toml` has claimed `license = "MIT"` for the whole life of the project with no `LICENSE` file to back it. GitHub showed no license badge, and anyone doing diligence before adopting waxum found a bare assertion. This adds the file.

## `1047c0a` — nightly pin and upstream pinning policy (IMT-18)

The toolchain requirement was something you discovered from a failed build. Now it is stated where you look before building:

- **README → Toolchain / Dependencies** — the pin, why it is there, and that `rustup` installs it for you from `rust-toolchain.toml`.
- **CONTRIBUTING → Toolchain / Upstream dependency policy** — same, plus the rules for the git-pinned crates, and an explicit "do not run `rustup default nightly`" (it sets a floating global nightly that drifts from what we build against).
- **`docs/DEPENDENCIES.md`** (new) — the risk note: what we pin, why git and not crates.io, what it costs downstream consumers, and the bump cadence.
- **CONTRIBUTING → Releasing** — reviewing the upstream revision is now step 1 of the release checklist. Reviewing, not necessarily bumping; staying put is a valid outcome, not looking is not.

### Two stale premises corrected while writing this

1. **It is eight crates, not six, and one unpublished crate is what forces the git pin — not the set.** Seven of the eight are on crates.io at 0.7.0; `whatsapp-rust-chat-store` is not. Because the eight share types across their public APIs, they have to resolve from one source, so one unpublished crate drags all eight onto git.
2. **`portable_simd` no longer forces nightly at the revision we pin.** Upstream removed SIMD from its tree, declares a stable MSRV, and gates no unstable features; waxum declares none of its own.

### The pin stays

Point 2 is not a plan to get off nightly in this release. Nobody has run `cargo build` / `clippy` / `test` on stable end to end, and absence of feature gates in first-party sources is evidence, not proof — an unstable feature can still arrive transitively. The pin holds until a stable build is verified green. The docs say exactly that rather than overclaiming in either direction, and the follow-up is tracked in #87, linked from both the README and the risk note.

Forking or vendoring `whatsapp-rust` remains explicitly rejected; `docs/DEPENDENCIES.md` says so in the text. Making the exposure legible is the mitigation.

## Verification

Docs-only across both commits — no Rust sources touched, so no build impact. Internal links checked: `docs/DEPENDENCIES.md` resolves from README and CONTRIBUTING, `../CONTRIBUTING.md#releasing` resolves back, and the `## Releasing` anchor exists.
