### PR TITLE
docs: make the nightly pin installable and say what stable does

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,43 @@ toolchain on your first `cargo` invocation in this directory. Do not run
 `rustup default nightly` — that sets a floating latest-nightly globally,
 which is not what this project builds against and will drift.
 
+If you would rather install it explicitly, or want to confirm which
+compiler you are on:
+
+```sh
+rustup toolchain install nightly-2026-04-05 --component rustfmt --component clippy
+rustup show active-toolchain   # from the repo root; expect nightly-2026-04-05-<host>
+```
+
+The components matter: `cargo fmt --check` and `cargo clippy` are both
+quality gates below, and neither exists on a toolchain installed without
+them.
+
+### If you are not using rustup
+
+`rust-toolchain.toml` is a `rustup` feature. A distro-packaged, Homebrew,
+or Nix `cargo` does not read it — it builds with whatever toolchain it
+is, silently, with no warning that the pin was ignored. This is the
+failure mode most likely to waste your afternoon, because it does not
+look like a toolchain problem. Check `cargo --version` first.
+
+### If you build on stable anyway
+
+We do not know what happens, and we would rather say so than guess: no
+one has run a stable build of waxum end to end. What we can tell you is
+the error the pin was introduced to prevent, which came from upstream,
+not from waxum:
+
+```
+error[E0554]: `#![feature]` may not be used on the stable release channel
+```
+
+That cause no longer exists at the revision we pin, so `cargo +stable
+build` may well succeed today. Unverified is not the same as supported —
+if you try it, please report what you get on
+[#87](https://github.com/imtaqin/waxum/issues/87); that is exactly the
+evidence the issue is waiting for.
+
 The pin exists because upstream `whatsapp-rust` used `portable_simd`, an
 unstable feature. That is no longer true at the revision we pin — upstream
 removed SIMD and declares a stable MSRV, and waxum uses no unstable

--- a/README.md
+++ b/README.md
@@ -191,6 +191,30 @@ not have to select it: the pin lives in `rust-toolchain.toml`, and
 `rustup` reads that file and installs the right toolchain on your first
 `cargo build`. If you have `rustup`, there is nothing to do.
 
+To install it up front, or to check what you are actually building with:
+
+```sh
+rustup toolchain install nightly-2026-04-05 --component rustfmt --component clippy
+rustup show active-toolchain   # from the repo root; expect nightly-2026-04-05-<host>
+```
+
+Do not run `rustup default nightly`. That selects a floating latest
+nightly globally, which is not what this project builds against.
+
+**Without `rustup`, the pin does not apply.** `rust-toolchain.toml` is a
+`rustup` feature; a distro-packaged, Homebrew, or Nix `cargo` ignores it
+silently — no warning, no error, just a different compiler than the one
+we test. If a build fails in a way this section does not explain, check
+`cargo --version` before anything else.
+
+If you force stable — `cargo +stable build` — we cannot tell you what
+happens, because nobody has run it. Historically it failed inside
+upstream `whatsapp-rust` with [`error[E0554]: #![feature] may not be used
+on the stable release channel`](https://doc.rust-lang.org/error_codes/E0554.html),
+which is the error this pin was introduced to prevent. That cause is gone
+at the revision we now pin, so a stable build may well succeed — it is
+simply unverified, and therefore unsupported.
+
 The pin is historical. Upstream `whatsapp-rust` used the unstable
 `portable_simd` feature, which is nightly-only; at the revision waxum
 currently pins, upstream has removed SIMD from its tree and declares a

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -87,6 +87,20 @@ is not "verified", and nobody has run a stable build end to end. Until
 someone does, the pin stays and this is the honest description of it.
 Tracked in [#87](https://github.com/imtaqin/waxum/issues/87).
 
+Removing the pin is not a one-line change to `rust-toolchain.toml`. It
+needs a stable build of the full dependency graph — the eight upstream
+crates included, since they are what forced nightly in the first place —
+plus the quality gates and a live pairing smoke test, on the pinned
+revision. Until that has been done once, treat `cargo +stable build` as
+unsupported rather than broken; the distinction is that we have no
+evidence either way. `error[E0554]` from an upstream crate is the
+historical failure signature to look for.
+
+Note also that the pin and the upstream revision are coupled. Bumping the
+revision (below) can reintroduce an unstable feature upstream and make
+nightly load-bearing again, which is one more reason the bump is a
+deliberate per-release decision rather than a background upgrade.
+
 ## Bump cadence
 
 **The upstream revision is reviewed once per release.** Not on a cron, not


### PR DESCRIPTION
Follow-up to #102, which documented the nightly pin and the upstream git-pinning policy. That PR stated the requirement and the reason; this one closes the two gaps a contributor hits first.

## What changes

**An install block you can paste.** The docs said "rustup handles it", which is true and unhelpful if you want to set the toolchain up ahead of time or confirm what you are on. README and CONTRIBUTING now carry:

```sh
rustup toolchain install nightly-2026-04-05 --component rustfmt --component clippy
rustup show active-toolchain
```

CONTRIBUTING notes why the components are not optional: `cargo fmt --check` and `cargo clippy` are both quality gates, and neither exists on a toolchain installed without them.

**The two ways the pin silently fails.**

- *No rustup.* `rust-toolchain.toml` is a rustup feature. A distro, Homebrew, or Nix `cargo` ignores it with no warning and no error. This is the expensive failure because it does not look like a toolchain problem — you get a compiler we do not test, and the first symptom is somewhere else entirely. Both docs now say to check `cargo --version` first.
- *Forced stable.* We do not know what `cargo +stable build` does, because nobody has run it. Rather than invent a plausible error, the docs name the historical signature — `error[E0554]: #![feature] may not be used on the stable release channel`, from upstream `whatsapp-rust`, which is the error the pin was introduced to prevent — then state plainly that the cause is gone at the revision we now pin, so it may well succeed. Unverified is not the same as supported.

Anyone who does try stable is pointed at #87, which is waiting for precisely that evidence.

**Coupling made explicit.** `docs/DEPENDENCIES.md` now records that the pin and the upstream revision move together: a revision bump can reintroduce an unstable feature upstream and make nightly load-bearing again. One more reason the bump is a per-release decision rather than a background upgrade.

## Scope

Docs only, no code. Consistent with the standing decision on IMT-18: we do not fork `whatsapp-rust` and we do not try to get off nightly — we make the constraint legible. Nothing here attempts a stable build or a workaround.

## Verification

Every nightly version string in README, CONTRIBUTING, and `docs/DEPENDENCIES.md` was checked against `rust-toolchain.toml` — all read `nightly-2026-04-05`. The component list in the install command matches `components = ["rustfmt", "clippy"]` in the same file.

Not verified, and deliberately not claimed anywhere in the diff: whether waxum builds on stable. This environment has no cargo or rustup, and running it was out of scope regardless. The docs say we do not know, because we do not.

Refs #87. Closes the remaining W2 acceptance criteria on IMT-18.