### PR TITLE
chore: trust hygiene — endpoint count, PR template, commit-msg hook, CLAUDE.md

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Reject commit messages that contain Claude/Anthropic authorship attribution.
+# Activate for your clone: git config core.hooksPath .githooks
+
+f="$1"
+[ -f "$f" ] || exit 0
+
+if grep -qiE 'Co-Authored-By:.*[Cc]laude|noreply@anthropic\.com|Generated with \[?Claude|🤖 Generated with' "$f"; then
+    echo "commit-msg: rejected — remove Claude/Anthropic attribution from the commit message before committing." >&2
+    echo "  (strip Co-Authored-By: Claude … and Generated with Claude Code lines)" >&2
+    exit 1
+fi

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? One sentence. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / endpoint
+- [ ] Refactor
+- [ ] Tests
+- [ ] Docs / chore
+
+## Checklist
+
+- [ ] `cargo test` passes locally
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] New tests added for new behaviour
+- [ ] No `Co-Authored-By: Claude` or `Generated with Claude Code` trailers in commits
+
+## Related issues
+
+<!-- Closes #XXX -->

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ temp/
 postman/
 waxum.db
 waxum.db-*
+
+# AI agent working directory
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# Claude / AI agent instructions for the waxum repo
+
+## Commit messages
+
+Do NOT add any of the following to commit messages:
+
+- `Co-Authored-By: Claude …`
+- `Co-Authored-By: Claude Opus …` / `Co-Authored-By: Claude Sonnet …`
+- `Generated with Claude Code`
+- `🤖 Generated with …`
+- Any line containing `noreply@anthropic.com`
+
+These trailers are stripped by the `commit-msg` hook and are unwanted in
+this repo's history. Omit them entirely; do not add them expecting the
+hook to clean up.
+
+## Code style
+
+Follow the conventions in CONTRIBUTING.md:
+- `cargo fmt` required
+- `cargo clippy -- -D warnings` must be clean
+- No `//` narrative comments in new code
+- Small commits, imperative subject line
+- No emojis in code, comments, or commits
+
+## Scope discipline
+
+- Do not open new endpoints in v0.13.0 — the release theme is credibility
+  over features.
+- If a test surfaces a defect, file it separately; do not fold the fix into
+  the test PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ happened once here (#90 surfaced the bug fixed by #93).
 ```sh
 git clone https://github.com/imtaqin/waxum.git
 cd waxum
+git config core.hooksPath .githooks   # activate the repo's commit-msg and other hooks
 ```
 
 ## Toolchain

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Native single-binary. Multi-session. Multi-DB. Webhooks + HMAC. JWT + Bearer. Swagger. Prometheus. NATS JetStream (optional).
 
-Production-grade. **130+ REST endpoints across 22 feature modules.**
+Production-grade. **180+ REST endpoints across 29 feature modules.**
 
 ## Features
 


### PR DESCRIPTION
## Summary

Closes IMT-17 (trust hygiene) and IMT-30 (co-author trailer prevention).

- **README.md**: reconcile endpoint count to `180+` across `29` modules (was `130+/22`; actual count is 182 `.route()` registrations in 29 handler modules)
- **GitHub repo description**: updated to match (done directly via API — `180+ endpoints across 29 modules`)
- **`.github/pull_request_template.md`**: new PR template for outside contributors (gates the W3 good-first-issue funnel)
- **`CLAUDE.md`**: repo-level instructions for AI agents — no `Co-Authored-By: Claude` or `Generated with Claude Code` trailers
- **`.githooks/commit-msg`**: rejects commits carrying Claude/Anthropic attribution; activate with `git config core.hooksPath .githooks` after cloning (documented in CONTRIBUTING.md)
- **`.gitignore`**: add `.claude/` to prevent accidental commits of the agent working directory

## Test plan

- [ ] README renders `180+ REST endpoints across 29 feature modules`
- [ ] GitHub shows MIT license badge (LICENSE already in dev)
- [ ] PR template appears when opening a new PR against dev
- [ ] commit-msg hook rejects a message containing `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`