### PR TITLE
fix(docker): copy vendored chat store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
 RUN rustup default nightly
 
 COPY Cargo.toml Cargo.lock* ./
+COPY vendor/ ./vendor/
 
 RUN mkdir -p src && \
     echo 'fn main() { println!("dummy"); }' > src/main.rs


### PR DESCRIPTION
## Summary

Copy the vendored `whatsapp-rust-chat-store` path dependency into the Rust builder before either Cargo build stage.

This fixes container builds after the WhatsApp-Rust upgrade: Cargo can resolve `vendor/whatsapp-rust-chat-store` during both the dependency-cache build and final release build.

## Type of change

- [x] Bug fix
- [ ] New feature / endpoint
- [ ] Refactor
- [ ] Tests
- [ ] Docs / chore

## Checklist

- [x] `cargo test` passes locally
- [x] `cargo clippy -- -D warnings` passes
- [ ] New tests added for new behaviour
- [x] No `Co-Authored-By: Claude` or `Generated with Claude Code` trailers in commits

## Related issues

None.